### PR TITLE
WIN-017: Set up test infrastructure with Vitest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ Desktop.ini
 *.log
 ~/.clui-debug.log
 
+# Test coverage
+coverage/
+
 # Temporary files
 *.tmp
 *.bak

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,96 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What This Is
+
+Clui CC is an Electron desktop overlay that wraps the Claude Code CLI (`claude -p --output-format stream-json`) in a floating pill UI with multi-tab sessions, permission approval, marketplace, and voice input. It does NOT call the Anthropic API directly — it spawns CLI subprocesses. Supports macOS (production) and Windows (beta).
+
+## Commands
+
+| Action | Command |
+|--------|---------|
+| Install deps | `npm install` |
+| Dev mode (hot-reload renderer) | `npm run dev` |
+| Type-check + build | `npm run build` |
+| Environment diagnostics | `npm run doctor` |
+| Debug logging | `CLUI_DEBUG=1 npm run dev` (writes `~/.clui-debug.log`) |
+| Toggle overlay | `Alt+Space` (macOS) / `Ctrl+Space` (Windows) |
+
+There is no test suite or linter configured. `npm run build` (TypeScript strict mode) is the only verification gate. Main process changes require full restart; renderer changes hot-reload.
+
+## Architecture (3-Layer)
+
+```
+Renderer (React 19 + Zustand 5 + Tailwind CSS 4 + Framer Motion)
+    ↕  contextBridge IPC (src/preload/index.ts)
+Main Process (Node.js / Electron 33)
+    ↕  spawns subprocess
+Claude Code CLI (claude -p --output-format stream-json)
+```
+
+### Data Flow: Prompt → Response
+
+```
+InputBar → window.clui.prompt(tabId, requestId, opts)
+  → ipcRenderer.invoke('clui:prompt')
+  → ControlPlane.prompt()
+  → RunManager spawns: claude -p --output-format stream-json --resume <sid>
+  → stdout NDJSON → StreamParser → EventNormalizer → NormalizedEvent
+  → ControlPlane broadcasts via IPC
+  → useClaudeEvents hook → sessionStore.handleNormalizedEvent()
+  → React re-renders
+```
+
+### Key Files by Concern
+
+| Concern | File |
+|---------|------|
+| Tab lifecycle & state machine | `src/main/claude/control-plane.ts` |
+| Spawning Claude CLI processes | `src/main/claude/run-manager.ts` |
+| Raw NDJSON → canonical events | `src/main/claude/event-normalizer.ts` |
+| Permission hook HTTP server | `src/main/hooks/permission-server.ts` |
+| All types & IPC channel names | `src/shared/types.ts` |
+| Zustand state store | `src/renderer/stores/sessionStore.ts` |
+| Theme / color system | `src/renderer/theme.ts` |
+| Window creation & IPC handlers | `src/main/index.ts` |
+| Typed IPC bridge | `src/preload/index.ts` |
+| Marketplace catalog | `src/main/marketplace/catalog.ts` |
+
+## Conventions
+
+- **TypeScript strict mode** — zero errors required, `npm run build` must pass.
+- **`IPC.*` constants** for all IPC channel names (defined in `src/shared/types.ts`) — never hardcode strings.
+- **`useColors()` hook** for all color references in renderer — never hardcode color values.
+- **Narrow Zustand selectors** with custom equality functions to prevent re-renders during streaming.
+- **Phosphor icons** (`@phosphor-icons/react`) — no other icon libraries.
+- **Framer Motion** for animations.
+- **Tab state transitions** go through ControlPlane only — never mutate tab state from renderer.
+- Do not import main-process modules from renderer or vice versa — preload bridge is the only crossing point.
+- Do not use `node-pty` for new features — it's legacy; prefer `RunManager` (stdio-based).
+- Do not add network calls — the app is nearly offline (only marketplace fetches from GitHub).
+- Do not use Electron `remote` module — disabled for security.
+
+## Security Rules — Do Not Break
+
+- Permission server binds to `127.0.0.1` only (never `0.0.0.0`).
+- Per-launch app secret (random UUID) validates hook requests.
+- Per-run tokens route permission responses to correct tab.
+- `CLAUDECODE` env var is removed from spawned processes.
+- Sensitive fields masked via `maskSensitiveFields()` before display.
+- 5-minute auto-deny timeout on unanswered permissions.
+
+## Adding Features — Wiring Checklist
+
+**New IPC channel:** Add to `IPC` const in `src/shared/types.ts` → handler in `src/main/index.ts` → expose in `src/preload/index.ts` → call via `window.clui.*`.
+
+**New event type from CLI:** Add raw type to `ClaudeEvent` union in `src/shared/types.ts` → add normalized form to `NormalizedEvent` → handle in `EventNormalizer.normalize()` → handle in `sessionStore.handleNormalizedEvent()`.
+
+**New tab state field:** Add to `TabState` in `src/shared/types.ts` → initialize in `createTab()` in both ControlPlane and sessionStore → update only via ControlPlane events.
+
+## Common Pitfalls
+
+- Forgetting to restart dev server after main-process changes (renderer hot-reloads, main does not).
+- Adding raw color values instead of `useColors()` — breaks theming.
+- Mutating tab state from renderer instead of going through ControlPlane.
+- Not handling `session_dead` event — crashed Claude processes must transition tab to `dead` status.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -5,7 +5,7 @@
 
 ## What This Project Is
 
-Clui CC is a **macOS-only Electron overlay** that wraps the Claude Code CLI (`claude -p --output-format stream-json`) in a floating pill UI. It is NOT a web app, NOT a VS Code extension, and does NOT call the Anthropic API directly — it spawns CLI subprocesses.
+Clui CC is an **Electron desktop overlay** (macOS production, Windows beta) that wraps the Claude Code CLI (`claude -p --output-format stream-json`) in a floating pill UI. It is NOT a web app, NOT a VS Code extension, and does NOT call the Anthropic API directly — it spawns CLI subprocesses.
 
 ## Quick Reference
 
@@ -87,6 +87,7 @@ All IPC and event types live in `src/shared/types.ts`. Key types:
 4. **Narrow Zustand selectors** with custom equality functions for performance
 5. **All new IPC channels** must be added to `src/shared/types.ts` AND wired in both `src/preload/index.ts` and `src/main/index.ts`
 6. **Tab state transitions** go through `ControlPlane` only — never mutate tab state directly
+7. **Always persist the Claude session ID** — whenever a session is created or resumed, save the session ID to a durable location (e.g., a file in `~/.claude/` or app config) so it can be recovered if the app or process crashes. Never rely solely on in-memory state for session tracking. If the session crashes, it must be resumable via `claude --resume <session-id>` without manual lookup.
 
 ### Security — Do Not Break
 
@@ -153,11 +154,55 @@ All IPC and event types live in `src/shared/types.ts`. Key types:
 
 No telemetry. No analytics. No auto-update.
 
+## Development Workflow — Mandatory for All Issues
+
+Every issue (bug fix, feature, refactor) MUST follow this workflow strictly:
+
+### 1. Branch from main
+```bash
+git checkout main && git pull
+git checkout -b WIN-XXX/short-description   # e.g. WIN-001/cross-platform-binary-detection
+```
+Branch name MUST start with the issue prefix (e.g. `WIN-001`).
+
+### 2. TDD — Tests First, Then Code
+1. **Write failing tests first** that cover the expected behavior, edge cases, and error paths.
+2. **Run tests** — confirm they fail (red).
+3. **Write the minimum code** to make all tests pass (green).
+4. **Refactor** if needed — tests must stay green.
+
+Never skip TDD. Never write implementation before tests. If you're unsure what to test, define acceptance criteria from the issue before writing any code.
+
+```bash
+npm run test          # run all tests
+npm run test:watch    # watch mode during development
+```
+
+### 3. Commit, Push, and Create PR
+```bash
+git add <specific files>
+git commit -m "WIN-XXX: <descriptive message>"
+git push -u origin WIN-XXX/short-description
+gh pr create --title "WIN-XXX: <title>" --body "Closes #<issue-number>..."
+```
+
+- Commit message MUST start with the issue prefix: `WIN-XXX: ...`
+- PR MUST reference the issue it closes: `Closes #N`
+- One PR per issue. Do not bundle unrelated changes.
+- Do not merge your own PR without review.
+
+### 4. PR Checklist
+- [ ] All new code has tests written BEFORE the implementation
+- [ ] `npm run build` passes with zero errors
+- [ ] `npm run test` passes with zero failures
+- [ ] No hardcoded platform assumptions (test on both macOS and Windows)
+- [ ] PR description explains what changed and why
+
 ## Common Pitfalls
 
 1. **Forgetting to restart dev server** after main-process changes — renderer hot-reloads but main does not
 2. **Adding raw color values** instead of using `useColors()` — breaks theming
 3. **Mutating tab state from renderer** instead of going through ControlPlane events
 4. **Hardcoding IPC strings** instead of using `IPC.*` constants
-5. **Testing on non-macOS** — this is macOS-only (transparent windows, node-pty bindings)
-6. **Not handling the `session_dead` event** — if a Claude process crashes, the tab must transition to `dead` status
+5. **Not handling the `session_dead` event** — if a Claude process crashes, the tab must transition to `dead` status
+6. **Writing implementation before tests** — all development is TDD, tests first

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "clui",
       "version": "0.1.0",
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "framer-motion": "^12.35.1",
@@ -21,6 +22,7 @@
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^4.3.0",
+        "@vitest/coverage-v8": "^4.1.0",
         "autoprefixer": "^10.4.0",
         "electron": "^33.0.0",
         "electron-builder": "^25.0.0",
@@ -30,7 +32,8 @@
         "react-dom": "^19.0.0",
         "tailwindcss": "^4.2.1",
         "typescript": "^5.7.0",
-        "vite": "^6.0.0"
+        "vite": "^6.0.0",
+        "vitest": "^4.1.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -329,6 +332,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@develar/schema-utils": {
@@ -1833,6 +1846,13 @@
         "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@szmarczak/http-timer": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
@@ -2196,6 +2216,17 @@
         "@types/responselike": "^1.0.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -2204,6 +2235,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2372,6 +2410,150 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.0.tgz",
+      "integrity": "sha512-nDWulKeik2bL2Va/Wl4x7DLuTKAXa906iRFooIRPR+huHkcvp9QDkPQ2RJdmjOFrqOqvNfoSQLF68deE3xC3CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.0",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.0",
+        "vitest": "4.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.0.tgz",
+      "integrity": "sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.0.tgz",
+      "integrity": "sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.0",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.0.tgz",
+      "integrity": "sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.0.tgz",
+      "integrity": "sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.0",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.0.tgz",
+      "integrity": "sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.0.tgz",
+      "integrity": "sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.0.tgz",
+      "integrity": "sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.0",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@xmldom/xmldom": {
@@ -2712,6 +2894,35 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/astral-regex": {
       "version": "2.0.0",
@@ -3226,6 +3437,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -4342,6 +4563,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -4453,6 +4681,26 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/exponential-backoff": {
@@ -5112,6 +5360,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -5431,6 +5686,45 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
@@ -5986,6 +6280,47 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/make-fetch-happen": {
@@ -7390,6 +7725,17 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -7568,6 +7914,13 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pe-library": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/pe-library/-/pe-library-0.4.1.tgz",
@@ -7596,6 +7949,19 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/plist": {
       "version": "3.1.0",
@@ -8199,6 +8565,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -8364,6 +8737,13 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stat-mode": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz",
@@ -8373,6 +8753,13 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -8624,6 +9011,23 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -8659,17 +9063,14 @@
         }
       }
     },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tmp": {
@@ -9078,17 +9479,86 @@
         }
       }
     },
-    "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+    "node_modules/vitest": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.0.tgz",
+      "integrity": "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.0",
+        "@vitest/mocker": "4.1.0",
+        "@vitest/pretty-format": "4.1.0",
+        "@vitest/runner": "4.1.0",
+        "@vitest/snapshot": "4.1.0",
+        "@vitest/spy": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
       "engines": {
-        "node": ">=12"
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
       },
       "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.0",
+        "@vitest/browser-preview": "4.1.0",
+        "@vitest/browser-webdriverio": "4.1.0",
+        "@vitest/ui": "4.1.0",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
       }
     },
     "node_modules/wcwidth": {
@@ -9115,6 +9585,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wide-align": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "dev": "electron-vite dev",
     "build": "electron-vite build",
     "preview": "electron-vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
     "doctor": "bash scripts/doctor.sh",
     "postinstall": "electron-builder install-app-deps && node scripts/postinstall.js"
   },
@@ -42,6 +45,7 @@
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.0",
+    "@vitest/coverage-v8": "^4.1.0",
     "autoprefixer": "^10.4.0",
     "electron": "^33.0.0",
     "electron-builder": "^25.0.0",
@@ -51,6 +55,7 @@
     "react-dom": "^19.0.0",
     "tailwindcss": "^4.2.1",
     "typescript": "^5.7.0",
-    "vite": "^6.0.0"
+    "vite": "^6.0.0",
+    "vitest": "^4.1.0"
   }
 }

--- a/tests/helpers/mock-electron.ts
+++ b/tests/helpers/mock-electron.ts
@@ -1,0 +1,87 @@
+/**
+ * Electron API mocks for testing main-process code outside of Electron.
+ *
+ * Usage: vi.mock('electron', () => mockElectron()) in your test file.
+ */
+
+import { vi } from 'vitest'
+
+export function mockElectron() {
+  return {
+    app: {
+      getPath: vi.fn((name: string) => {
+        const paths: Record<string, string> = {
+          userData: '/mock/userData',
+          temp: '/mock/temp',
+          home: '/mock/home',
+        }
+        return paths[name] ?? `/mock/${name}`
+      }),
+      getVersion: vi.fn(() => '33.0.0'),
+      getName: vi.fn(() => 'clui'),
+      isReady: vi.fn(() => true),
+      on: vi.fn(),
+      quit: vi.fn(),
+    },
+    BrowserWindow: vi.fn().mockImplementation(() => ({
+      loadURL: vi.fn(),
+      loadFile: vi.fn(),
+      on: vi.fn(),
+      once: vi.fn(),
+      show: vi.fn(),
+      hide: vi.fn(),
+      close: vi.fn(),
+      destroy: vi.fn(),
+      isDestroyed: vi.fn(() => false),
+      isVisible: vi.fn(() => true),
+      webContents: {
+        send: vi.fn(),
+        on: vi.fn(),
+        openDevTools: vi.fn(),
+      },
+      setIgnoreMouseEvents: vi.fn(),
+      setAlwaysOnTop: vi.fn(),
+      setBounds: vi.fn(),
+      getBounds: vi.fn(() => ({ x: 0, y: 0, width: 800, height: 600 })),
+    })),
+    ipcMain: {
+      handle: vi.fn(),
+      on: vi.fn(),
+      removeHandler: vi.fn(),
+    },
+    globalShortcut: {
+      register: vi.fn(() => true),
+      unregister: vi.fn(),
+      unregisterAll: vi.fn(),
+      isRegistered: vi.fn(() => false),
+    },
+    Tray: vi.fn().mockImplementation(() => ({
+      setContextMenu: vi.fn(),
+      setToolTip: vi.fn(),
+      setImage: vi.fn(),
+      setTemplateImage: vi.fn(),
+      on: vi.fn(),
+      destroy: vi.fn(),
+    })),
+    Menu: {
+      buildFromTemplate: vi.fn(() => ({})),
+    },
+    nativeImage: {
+      createFromPath: vi.fn(() => ({
+        setTemplateImage: vi.fn(),
+      })),
+    },
+    screen: {
+      getPrimaryDisplay: vi.fn(() => ({
+        workAreaSize: { width: 1920, height: 1080 },
+        scaleFactor: 1,
+      })),
+    },
+    shell: {
+      openExternal: vi.fn(),
+    },
+    net: {
+      request: vi.fn(),
+    },
+  }
+}

--- a/tests/helpers/mock-platform.test.ts
+++ b/tests/helpers/mock-platform.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { mockPlatform, withPlatform } from './mock-platform'
+
+describe('mockPlatform helper', () => {
+  it('overrides process.platform and restores it', () => {
+    const original = process.platform
+    const restore = mockPlatform('darwin')
+
+    expect(process.platform).toBe('darwin')
+
+    restore()
+    expect(process.platform).toBe(original)
+  })
+
+  it('withPlatform restores even if fn throws', async () => {
+    const original = process.platform
+
+    await expect(
+      withPlatform('linux', () => {
+        expect(process.platform).toBe('linux')
+        throw new Error('boom')
+      })
+    ).rejects.toThrow('boom')
+
+    expect(process.platform).toBe(original)
+  })
+})

--- a/tests/helpers/mock-platform.ts
+++ b/tests/helpers/mock-platform.ts
@@ -1,0 +1,30 @@
+/**
+ * Helper to mock process.platform for cross-platform tests.
+ *
+ * Usage:
+ *   const restore = mockPlatform('win32')
+ *   // ... test code ...
+ *   restore()
+ *
+ * Or use withPlatform() for automatic cleanup:
+ *   await withPlatform('win32', () => { ... })
+ */
+
+export type Platform = 'win32' | 'darwin' | 'linux'
+
+export function mockPlatform(platform: Platform): () => void {
+  const original = process.platform
+  Object.defineProperty(process, 'platform', { value: platform, writable: true })
+  return () => {
+    Object.defineProperty(process, 'platform', { value: original, writable: true })
+  }
+}
+
+export async function withPlatform<T>(platform: Platform, fn: () => T | Promise<T>): Promise<T> {
+  const restore = mockPlatform(platform)
+  try {
+    return await fn()
+  } finally {
+    restore()
+  }
+}

--- a/tests/unit/event-normalizer.test.ts
+++ b/tests/unit/event-normalizer.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect } from 'vitest'
+import { normalize } from '../../src/main/claude/event-normalizer'
+
+describe('EventNormalizer', () => {
+  describe('system/init events', () => {
+    it('normalizes a system init event to session_init', () => {
+      const raw = {
+        type: 'system' as const,
+        subtype: 'init' as const,
+        session_id: 'sess-123',
+        tools: ['Read', 'Write'],
+        model: 'claude-sonnet-4-5-20250514',
+        mcp_servers: [{ name: 'test', status: 'connected' }],
+        skills: ['skill-creator'],
+        claude_code_version: '2.1.71',
+        cwd: '/tmp',
+        permissionMode: 'acceptEdits',
+        agents: [],
+        plugins: [],
+        fast_mode_state: 'off',
+        uuid: 'uuid-1',
+      }
+
+      const result = normalize(raw)
+
+      expect(result).toHaveLength(1)
+      expect(result[0]).toMatchObject({
+        type: 'session_init',
+        sessionId: 'sess-123',
+        tools: ['Read', 'Write'],
+        model: 'claude-sonnet-4-5-20250514',
+      })
+    })
+
+    it('returns empty array for non-init system events', () => {
+      const raw = {
+        type: 'system' as const,
+        subtype: 'other' as any,
+        session_id: 'x',
+        cwd: '/',
+        tools: [],
+        mcp_servers: [],
+        model: '',
+        permissionMode: '',
+        agents: [],
+        skills: [],
+        plugins: [],
+        claude_code_version: '',
+        fast_mode_state: '',
+        uuid: '',
+      }
+      expect(normalize(raw)).toEqual([])
+    })
+  })
+
+  describe('stream events', () => {
+    it('normalizes text_delta to text_chunk', () => {
+      const raw = {
+        type: 'stream_event' as const,
+        session_id: 's1',
+        parent_tool_use_id: null,
+        uuid: 'u1',
+        event: {
+          type: 'content_block_delta' as const,
+          index: 0,
+          delta: { type: 'text_delta' as const, text: 'Hello' },
+        },
+      }
+
+      const result = normalize(raw)
+      expect(result).toEqual([{ type: 'text_chunk', text: 'Hello' }])
+    })
+
+    it('normalizes tool_use content_block_start to tool_call', () => {
+      const raw = {
+        type: 'stream_event' as const,
+        session_id: 's1',
+        parent_tool_use_id: null,
+        uuid: 'u1',
+        event: {
+          type: 'content_block_start' as const,
+          index: 1,
+          content_block: { type: 'tool_use' as const, id: 'tool-1', name: 'Read' },
+        },
+      }
+
+      const result = normalize(raw)
+      expect(result).toEqual([{
+        type: 'tool_call',
+        toolName: 'Read',
+        toolId: 'tool-1',
+        index: 1,
+      }])
+    })
+
+    it('normalizes input_json_delta to tool_call_update', () => {
+      const raw = {
+        type: 'stream_event' as const,
+        session_id: 's1',
+        parent_tool_use_id: null,
+        uuid: 'u1',
+        event: {
+          type: 'content_block_delta' as const,
+          index: 1,
+          delta: { type: 'input_json_delta' as const, partial_json: '{"path":' },
+        },
+      }
+
+      const result = normalize(raw)
+      expect(result).toEqual([{
+        type: 'tool_call_update',
+        toolId: '',
+        partialInput: '{"path":',
+      }])
+    })
+
+    it('normalizes content_block_stop to tool_call_complete', () => {
+      const raw = {
+        type: 'stream_event' as const,
+        session_id: 's1',
+        parent_tool_use_id: null,
+        uuid: 'u1',
+        event: {
+          type: 'content_block_stop' as const,
+          index: 1,
+        },
+      }
+
+      const result = normalize(raw)
+      expect(result).toEqual([{ type: 'tool_call_complete', index: 1 }])
+    })
+
+    it('returns empty for message_start/delta/stop structural events', () => {
+      for (const subType of ['message_start', 'message_delta', 'message_stop'] as const) {
+        const raw = {
+          type: 'stream_event' as const,
+          session_id: 's1',
+          parent_tool_use_id: null,
+          uuid: 'u1',
+          event: { type: subType, message: {}, delta: {}, usage: {} } as any,
+        }
+        expect(normalize(raw)).toEqual([])
+      }
+    })
+  })
+
+  describe('result events', () => {
+    it('normalizes successful result to task_complete', () => {
+      const raw = {
+        type: 'result' as const,
+        subtype: 'success' as const,
+        result: 'Done',
+        is_error: false,
+        session_id: 's1',
+        total_cost_usd: 0.05,
+        duration_ms: 1200,
+        num_turns: 3,
+        usage: { input_tokens: 100, output_tokens: 50 },
+      }
+
+      const result = normalize(raw)
+      expect(result).toHaveLength(1)
+      expect(result[0]).toMatchObject({
+        type: 'task_complete',
+        result: 'Done',
+        costUsd: 0.05,
+        durationMs: 1200,
+        numTurns: 3,
+        sessionId: 's1',
+      })
+    })
+
+    it('normalizes error result to error event', () => {
+      const raw = {
+        type: 'result' as const,
+        subtype: 'error' as const,
+        result: 'API key invalid',
+        is_error: true,
+        session_id: 's1',
+        total_cost_usd: 0,
+        duration_ms: 100,
+        num_turns: 0,
+        usage: {},
+      }
+
+      const result = normalize(raw)
+      expect(result).toEqual([{
+        type: 'error',
+        message: 'API key invalid',
+        isError: true,
+        sessionId: 's1',
+      }])
+    })
+  })
+
+  describe('unknown events', () => {
+    it('returns empty array for unknown event types', () => {
+      const raw = { type: 'completely_unknown' } as any
+      expect(normalize(raw)).toEqual([])
+    })
+  })
+})

--- a/tests/unit/stream-parser.test.ts
+++ b/tests/unit/stream-parser.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+import { StreamParser } from '../../src/main/stream-parser'
+import { Readable } from 'stream'
+
+describe('StreamParser', () => {
+  it('parses valid NDJSON lines into events', async () => {
+    const events: unknown[] = []
+    const input = new Readable({ read() {} })
+
+    const parser = StreamParser.fromStream(input)
+    parser.on('event', (e: unknown) => events.push(e))
+
+    const done = new Promise<void>((resolve) => input.on('end', () => setTimeout(resolve, 50)))
+
+    input.push('{"type":"system","subtype":"init","session_id":"abc"}\n')
+    input.push('{"type":"result","result":"done"}\n')
+    input.push(null)
+
+    await done
+
+    expect(events).toHaveLength(2)
+    expect(events[0]).toEqual({ type: 'system', subtype: 'init', session_id: 'abc' })
+    expect(events[1]).toEqual({ type: 'result', result: 'done' })
+  })
+
+  it('emits parse-error for invalid JSON lines', async () => {
+    const errors: string[] = []
+    const input = new Readable({ read() {} })
+
+    const parser = StreamParser.fromStream(input)
+    parser.on('parse-error', (line: string) => errors.push(line))
+
+    const done = new Promise<void>((resolve) => input.on('end', () => setTimeout(resolve, 50)))
+
+    input.push('not valid json\n')
+    input.push('{"type":"result"}\n')
+    input.push(null)
+
+    await done
+
+    expect(errors).toHaveLength(1)
+    expect(errors[0]).toContain('not valid json')
+  })
+
+  it('handles empty lines gracefully', async () => {
+    const events: unknown[] = []
+    const errors: string[] = []
+    const input = new Readable({ read() {} })
+
+    const parser = StreamParser.fromStream(input)
+    parser.on('event', (e: unknown) => events.push(e))
+    parser.on('parse-error', (line: string) => errors.push(line))
+
+    const done = new Promise<void>((resolve) => input.on('end', () => setTimeout(resolve, 50)))
+
+    input.push('\n')
+    input.push('  \n')
+    input.push('{"type":"result"}\n')
+    input.push(null)
+
+    await done
+
+    expect(events).toHaveLength(1)
+    expect(errors).toHaveLength(0)
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['tests/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      reportsDirectory: 'coverage',
+      include: ['src/main/**/*.ts', 'src/shared/**/*.ts'],
+      exclude: ['src/renderer/**', 'src/preload/**'],
+    },
+    // Allow mocking process.platform for cross-platform tests
+    unstubGlobals: true,
+    restoreMocks: true,
+  },
+})


### PR DESCRIPTION
## Summary

Closes #18

- Adds **Vitest** + **v8 coverage** as the project test runner
- Creates test directory structure (`tests/unit/`, `tests/integration/`, `tests/smoke/`, `tests/helpers/`)
- Provides **Electron API mocks** for testing main-process code without Electron runtime
- Provides **cross-platform mocks** (`mockPlatform`, `withPlatform`) to simulate `win32`/`darwin`/`linux` in tests
- Adds **15 baseline tests** covering `StreamParser` and `EventNormalizer`
- Updates `AGENTS.md` with mandatory TDD workflow and session persistence rule
- Adds `CLAUDE.md` for agent guidance

## Test plan

- [x] `npm run test` — 15 tests pass (3 StreamParser, 9 EventNormalizer, 2 mockPlatform, 1 helper)
- [x] `npm run test:coverage` — coverage report generated for `src/main/` and `src/shared/`
- [x] `npm run build` — still passes with zero errors
- [ ] Verify `npm run test` works on macOS (cross-platform)