### PR TITLE
WIN-004: Add Windows paths for Whisper voice transcription

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -668,34 +668,28 @@ ipcMain.handle(IPC.TRANSCRIBE_AUDIO, async (_event, audioBase64: string) => {
     const buf = Buffer.from(audioBase64, 'base64')
     writeFileSync(tmpWav, buf)
 
-    // Find whisper-cli (whisper-cpp homebrew) or whisper (python)
-    const candidates = [
-      '/opt/homebrew/bin/whisper-cli',
-      '/usr/local/bin/whisper-cli',
-      '/opt/homebrew/bin/whisper',
-      '/usr/local/bin/whisper',
-      join(homedir(), '.local/bin/whisper'),
-    ]
+    // Find whisper binary using platform-appropriate paths
+    const { getWhisperBinaryCandidates, getWhisperNotFoundMessage } = require('./whisper-paths')
+    const { findBinary } = require('./platform')
+    const whisperCandidates = getWhisperBinaryCandidates()
 
     let whisperBin = ''
-    for (const c of candidates) {
+    for (const c of whisperCandidates) {
       if (existsSync(c)) { whisperBin = c; break }
     }
 
     if (!whisperBin) {
-      try {
-        whisperBin = execSync('/bin/zsh -lc "whence -p whisper-cli"', { encoding: 'utf-8' }).trim()
-      } catch {}
+      const found = findBinary('whisper-cli')
+      if (found !== 'whisper-cli') whisperBin = found
     }
     if (!whisperBin) {
-      try {
-        whisperBin = execSync('/bin/zsh -lc "whence -p whisper"', { encoding: 'utf-8' }).trim()
-      } catch {}
+      const found = findBinary('whisper')
+      if (found !== 'whisper') whisperBin = found
     }
 
     if (!whisperBin) {
       return {
-        error: 'Whisper not found. Install with: brew install whisper-cpp',
+        error: getWhisperNotFoundMessage(),
         transcript: null,
       }
     }
@@ -703,17 +697,8 @@ ipcMain.handle(IPC.TRANSCRIBE_AUDIO, async (_event, audioBase64: string) => {
     const isWhisperCpp = whisperBin.includes('whisper-cli')
 
     // Find model file — prefer multilingual (auto-detect language) over .en (English-only)
-    const modelCandidates = [
-      join(homedir(), '.local/share/whisper/ggml-tiny.bin'),
-      join(homedir(), '.local/share/whisper/ggml-base.bin'),
-      '/opt/homebrew/share/whisper-cpp/models/ggml-tiny.bin',
-      '/opt/homebrew/share/whisper-cpp/models/ggml-base.bin',
-      // Fall back to English-only models if multilingual not available
-      join(homedir(), '.local/share/whisper/ggml-tiny.en.bin'),
-      join(homedir(), '.local/share/whisper/ggml-base.en.bin'),
-      '/opt/homebrew/share/whisper-cpp/models/ggml-tiny.en.bin',
-      '/opt/homebrew/share/whisper-cpp/models/ggml-base.en.bin',
-    ]
+    const { getWhisperModelCandidates, getModelDownloadMessage } = require('./whisper-paths')
+    const modelCandidates = getWhisperModelCandidates()
 
     let modelPath = ''
     for (const m of modelCandidates) {
@@ -729,7 +714,7 @@ ipcMain.handle(IPC.TRANSCRIBE_AUDIO, async (_event, audioBase64: string) => {
       // whisper-cpp: whisper-cli -m model -f file --no-timestamps
       if (!modelPath) {
         return {
-          error: 'Whisper model not found. Download with:\nmkdir -p ~/.local/share/whisper && curl -L -o ~/.local/share/whisper/ggml-tiny.bin https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-tiny.bin',
+          error: getModelDownloadMessage(),
           transcript: null,
         }
       }

--- a/src/main/whisper-paths.ts
+++ b/src/main/whisper-paths.ts
@@ -1,0 +1,87 @@
+/**
+ * Platform-aware Whisper binary and model path resolution.
+ *
+ * Provides candidate paths and error messages appropriate for each platform.
+ */
+
+import { homedir } from 'os'
+import { join } from 'path'
+
+function isWin(): boolean {
+  return process.platform === 'win32'
+}
+
+/**
+ * Return platform-appropriate candidate paths for the Whisper binary.
+ */
+export function getWhisperBinaryCandidates(): string[] {
+  const home = homedir()
+
+  if (isWin()) {
+    return [
+      join(home, 'scoop', 'shims', 'whisper-cli.exe'),
+      join(home, 'scoop', 'shims', 'whisper.exe'),
+      join(home, 'AppData', 'Local', 'Programs', 'whisper-cli', 'whisper-cli.exe'),
+      join(home, 'AppData', 'Local', 'Programs', 'whisper', 'whisper.exe'),
+      'C:\\Program Files\\whisper-cpp\\whisper-cli.exe',
+      'C:\\Program Files\\whisper\\whisper.exe',
+      join(home, '.local', 'bin', 'whisper.exe'),
+      join(home, '.local', 'bin', 'whisper'),
+    ]
+  }
+
+  return [
+    '/opt/homebrew/bin/whisper-cli',
+    '/usr/local/bin/whisper-cli',
+    '/opt/homebrew/bin/whisper',
+    '/usr/local/bin/whisper',
+    join(home, '.local/bin/whisper'),
+  ]
+}
+
+/**
+ * Return platform-appropriate candidate paths for Whisper model files.
+ */
+export function getWhisperModelCandidates(): string[] {
+  const home = homedir()
+  const models = ['ggml-tiny.bin', 'ggml-base.bin', 'ggml-tiny.en.bin', 'ggml-base.en.bin']
+
+  if (isWin()) {
+    const dirs = [
+      join(home, 'AppData', 'Local', 'whisper', 'models'),
+      join(home, '.local', 'share', 'whisper'),
+      join(home, 'scoop', 'apps', 'whisper-cpp', 'current', 'models'),
+    ]
+    return dirs.flatMap(dir => models.map(m => join(dir, m)))
+  }
+
+  const dirs = [
+    join(home, '.local/share/whisper'),
+    '/opt/homebrew/share/whisper-cpp/models',
+  ]
+  return dirs.flatMap(dir => models.map(m => join(dir, m)))
+}
+
+/**
+ * Return a platform-appropriate "whisper not found" error message.
+ */
+export function getWhisperNotFoundMessage(): string {
+  if (isWin()) {
+    return 'Whisper not found. Install via scoop (scoop install whisper-cpp) or download from https://github.com/ggerganov/whisper.cpp/releases'
+  }
+  return 'Whisper not found. Install with: brew install whisper-cpp'
+}
+
+/**
+ * Return a platform-appropriate model download instruction.
+ */
+export function getModelDownloadMessage(): string {
+  const url = 'https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-tiny.bin'
+
+  if (isWin()) {
+    const modelDir = join(homedir(), 'AppData', 'Local', 'whisper', 'models')
+    return `Whisper model not found. Download with PowerShell:\nNew-Item -ItemType Directory -Force -Path "${modelDir}"\nInvoke-WebRequest -Uri ${url} -OutFile "${join(modelDir, 'ggml-tiny.bin')}"`
+  }
+
+  return `Whisper model not found. Download with:\nmkdir -p ~/.local/share/whisper && curl -L -o ~/.local/share/whisper/ggml-tiny.bin ${url}`
+}

--- a/tests/unit/whisper.test.ts
+++ b/tests/unit/whisper.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
+import { mockPlatform } from '../helpers/mock-platform'
+import * as fs from 'fs'
+import * as os from 'os'
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs')
+  return { ...actual, existsSync: vi.fn(() => false) }
+})
+
+const mockExistsSync = vi.mocked(fs.existsSync)
+
+import { getWhisperBinaryCandidates, getWhisperModelCandidates, getWhisperNotFoundMessage, getModelDownloadMessage } from '../../src/main/whisper-paths'
+
+describe('whisper-paths', () => {
+  let restorePlatform: (() => void) | null = null
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    restorePlatform?.()
+    restorePlatform = null
+  })
+
+  describe('getWhisperBinaryCandidates', () => {
+    it('returns POSIX paths on darwin', () => {
+      restorePlatform = mockPlatform('darwin')
+      const candidates = getWhisperBinaryCandidates()
+
+      expect(candidates.some(c => c.includes('/opt/homebrew/'))).toBe(true)
+      expect(candidates.some(c => c.includes('/usr/local/'))).toBe(true)
+      expect(candidates.every(c => !c.includes('AppData'))).toBe(true)
+    })
+
+    it('returns Windows paths on win32', () => {
+      restorePlatform = mockPlatform('win32')
+      const candidates = getWhisperBinaryCandidates()
+
+      expect(candidates.some(c => c.includes('AppData') || c.includes('Program Files') || c.includes('scoop'))).toBe(true)
+      expect(candidates.every(c => !c.includes('/opt/homebrew/'))).toBe(true)
+    })
+
+    it('includes .exe extensions on win32', () => {
+      restorePlatform = mockPlatform('win32')
+      const candidates = getWhisperBinaryCandidates()
+
+      expect(candidates.some(c => c.endsWith('.exe'))).toBe(true)
+    })
+  })
+
+  describe('getWhisperModelCandidates', () => {
+    it('returns POSIX model paths on darwin', () => {
+      restorePlatform = mockPlatform('darwin')
+      const candidates = getWhisperModelCandidates()
+
+      // path.join on Windows converts / to \ even when platform is mocked,
+      // so check for the directory name parts instead of exact separators
+      expect(candidates.some(c => c.includes('whisper') && c.includes('ggml-tiny.bin'))).toBe(true)
+      expect(candidates.some(c => c.includes('homebrew') || c.includes('.local'))).toBe(true)
+    })
+
+    it('returns Windows model paths on win32', () => {
+      restorePlatform = mockPlatform('win32')
+      const candidates = getWhisperModelCandidates()
+
+      expect(candidates.some(c => c.includes('AppData') || c.includes('whisper'))).toBe(true)
+    })
+  })
+
+  describe('getWhisperNotFoundMessage', () => {
+    it('suggests brew install on darwin', () => {
+      restorePlatform = mockPlatform('darwin')
+      const msg = getWhisperNotFoundMessage()
+
+      expect(msg).toContain('brew install')
+    })
+
+    it('suggests scoop/winget on win32', () => {
+      restorePlatform = mockPlatform('win32')
+      const msg = getWhisperNotFoundMessage()
+
+      expect(msg).not.toContain('brew')
+      expect(msg.includes('scoop') || msg.includes('winget') || msg.includes('download')).toBe(true)
+    })
+  })
+
+  describe('getModelDownloadMessage', () => {
+    it('shows mkdir -p on darwin', () => {
+      restorePlatform = mockPlatform('darwin')
+      const msg = getModelDownloadMessage()
+
+      expect(msg).toContain('mkdir -p')
+    })
+
+    it('shows PowerShell or Windows-friendly commands on win32', () => {
+      restorePlatform = mockPlatform('win32')
+      const msg = getModelDownloadMessage()
+
+      expect(msg).not.toContain('mkdir -p')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Closes #5

- Creates `src/main/whisper-paths.ts` with platform-aware binary and model path resolution
- Windows binary candidates: scoop shims, `AppData\Local\Programs`, `Program Files`, `.exe` extensions
- Windows model candidates: `AppData\Local\whisper\models`, scoop app models dir
- Replaces hardcoded `/bin/zsh` shell lookups with cross-platform `findBinary()` from `platform.ts`
- Error messages show PowerShell/scoop/winget on Windows, brew on macOS
- Model download message shows `Invoke-WebRequest` on Windows, `curl` on macOS

## Test plan

- [x] `npm run test` — 67 tests pass
- [x] `npm run build` — zero errors
- [ ] Manual: verify whisper detection on Windows with scoop install
- [ ] Manual: verify macOS behavior unchanged