### PR TITLE
WIN-007: Add configurable global shortcut with conflict recovery

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -9,6 +9,7 @@ import { fetchCatalog, listInstalled, installPlugin, uninstallPlugin } from './m
 import { log as _log, LOG_FILE, flushLogs } from './logger'
 import { getProjectSessionKey } from './session-path'
 import { getWindowConfig } from './window-config'
+import { loadShortcutConfig, saveShortcutConfig, getSafeAlternatives } from './shortcut-config'
 import { IPC } from '../shared/types'
 import type { RunOptions, NormalizedEvent, EnrichedError } from '../shared/types'
 
@@ -907,13 +908,28 @@ app.whenReady().then(() => {
   }
 
 
-  // Primary: Option+Space (2 keys, doesn't conflict with shell)
-  // Fallback: Cmd+Shift+K kept as secondary shortcut
-  const primaryShortcut = process.platform === 'win32' ? 'CommandOrControl+Space' : 'Alt+Space'
-  const registered = globalShortcut.register(primaryShortcut, () => toggleWindow(`shortcut ${primaryShortcut}`))
+  // Register user-configured shortcut with automatic fallback on conflict
+  const shortcutConfig = loadShortcutConfig()
+  let primaryShortcut = shortcutConfig.primary
+  let registered = globalShortcut.register(primaryShortcut, () => toggleWindow(`shortcut ${primaryShortcut}`))
+
   if (!registered) {
-    log(`${primaryShortcut} shortcut registration failed`)
+    log(`${primaryShortcut} shortcut registration failed — trying alternatives`)
+    // Try safe alternatives until one works
+    for (const alt of getSafeAlternatives()) {
+      registered = globalShortcut.register(alt, () => toggleWindow(`shortcut ${alt}`))
+      if (registered) {
+        primaryShortcut = alt
+        saveShortcutConfig({ primary: alt })
+        log(`Registered fallback shortcut: ${alt}`)
+        break
+      }
+    }
+    if (!registered) {
+      log('All shortcut alternatives failed')
+    }
   }
+  // Secondary shortcut always registered
   globalShortcut.register('CommandOrControl+Shift+K', () => toggleWindow('shortcut Cmd/Ctrl+Shift+K'))
 
   const trayIconPath = join(__dirname, process.platform === 'darwin' ? '../../resources/trayTemplate.png' : '../../resources/icon.png')

--- a/src/main/shortcut-config.ts
+++ b/src/main/shortcut-config.ts
@@ -1,0 +1,63 @@
+/**
+ * Global shortcut configuration — user-configurable toggle shortcut
+ * with conflict recovery and safe alternatives.
+ *
+ * Config persisted at ~/.claude/clui-shortcut.json
+ */
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs'
+import { join, dirname } from 'path'
+import { homedir } from 'os'
+
+const CONFIG_PATH = join(homedir(), '.claude', 'clui-shortcut.json')
+
+export interface ShortcutConfig {
+  primary: string
+}
+
+/**
+ * Returns the platform-appropriate default shortcut.
+ * - macOS: Alt+Space (doesn't conflict with Spotlight, which uses Cmd+Space)
+ * - Windows: Ctrl+Space (may conflict with IMEs — that's why we support alternatives)
+ */
+export function getDefaultShortcut(): string {
+  return process.platform === 'win32' ? 'CommandOrControl+Space' : 'Alt+Space'
+}
+
+/**
+ * Returns a list of safe alternative shortcuts that are unlikely to conflict
+ * with common system tools, IMEs, or other apps.
+ */
+export function getSafeAlternatives(): string[] {
+  return [
+    'CommandOrControl+Shift+Space',
+    'CommandOrControl+`',
+    'CommandOrControl+Shift+K',
+    'Alt+Shift+Space',
+    'CommandOrControl+Alt+Space',
+  ]
+}
+
+/**
+ * Load shortcut config from disk, or return defaults.
+ */
+export function loadShortcutConfig(): ShortcutConfig {
+  try {
+    if (existsSync(CONFIG_PATH)) {
+      const data = JSON.parse(readFileSync(CONFIG_PATH, 'utf-8'))
+      if (data.primary && typeof data.primary === 'string') {
+        return { primary: data.primary }
+      }
+    }
+  } catch {}
+
+  return { primary: getDefaultShortcut() }
+}
+
+/**
+ * Save shortcut config to disk.
+ */
+export function saveShortcutConfig(config: ShortcutConfig): void {
+  mkdirSync(dirname(CONFIG_PATH), { recursive: true })
+  writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2) + '\n')
+}

--- a/tests/unit/shortcut-config.test.ts
+++ b/tests/unit/shortcut-config.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
+import { mockPlatform } from '../helpers/mock-platform'
+import { getDefaultShortcut, getSafeAlternatives, ShortcutConfig, loadShortcutConfig, saveShortcutConfig } from '../../src/main/shortcut-config'
+import * as fs from 'fs'
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs')
+  return {
+    ...actual,
+    existsSync: vi.fn(() => false),
+    readFileSync: vi.fn(() => '{}'),
+    writeFileSync: vi.fn(),
+    mkdirSync: vi.fn(),
+  }
+})
+
+const mockExistsSync = vi.mocked(fs.existsSync)
+const mockReadFileSync = vi.mocked(fs.readFileSync)
+const mockWriteFileSync = vi.mocked(fs.writeFileSync)
+
+describe('shortcut-config', () => {
+  let restorePlatform: (() => void) | null = null
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    restorePlatform?.()
+    restorePlatform = null
+  })
+
+  describe('getDefaultShortcut', () => {
+    it('returns Ctrl+Space on win32', () => {
+      restorePlatform = mockPlatform('win32')
+      expect(getDefaultShortcut()).toBe('CommandOrControl+Space')
+    })
+
+    it('returns Alt+Space on darwin', () => {
+      restorePlatform = mockPlatform('darwin')
+      expect(getDefaultShortcut()).toBe('Alt+Space')
+    })
+  })
+
+  describe('getSafeAlternatives', () => {
+    it('returns multiple alternatives', () => {
+      const alts = getSafeAlternatives()
+      expect(alts.length).toBeGreaterThanOrEqual(3)
+    })
+
+    it('does not include the default shortcut', () => {
+      restorePlatform = mockPlatform('win32')
+      const def = getDefaultShortcut()
+      const alts = getSafeAlternatives()
+      expect(alts).not.toContain(def)
+    })
+  })
+
+  describe('loadShortcutConfig', () => {
+    it('returns default when config file does not exist', () => {
+      restorePlatform = mockPlatform('win32')
+      mockExistsSync.mockReturnValue(false)
+
+      const config = loadShortcutConfig()
+      expect(config.primary).toBe('CommandOrControl+Space')
+    })
+
+    it('returns saved shortcut when config file exists', () => {
+      mockExistsSync.mockReturnValue(true)
+      mockReadFileSync.mockReturnValue(JSON.stringify({ primary: 'Ctrl+Shift+Space' }))
+
+      const config = loadShortcutConfig()
+      expect(config.primary).toBe('Ctrl+Shift+Space')
+    })
+
+    it('falls back to default on corrupt config file', () => {
+      restorePlatform = mockPlatform('win32')
+      mockExistsSync.mockReturnValue(true)
+      mockReadFileSync.mockReturnValue('not json!!!!')
+
+      const config = loadShortcutConfig()
+      expect(config.primary).toBe('CommandOrControl+Space')
+    })
+  })
+
+  describe('saveShortcutConfig', () => {
+    it('writes config to file', () => {
+      const config: ShortcutConfig = { primary: 'Ctrl+Shift+Space' }
+      saveShortcutConfig(config)
+
+      expect(mockWriteFileSync).toHaveBeenCalledWith(
+        expect.any(String),
+        JSON.stringify(config, null, 2) + '\n',
+      )
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Closes #8

- User-configurable global hotkey persisted to `~/.claude/clui-shortcut.json`
- Auto-fallback on registration failure: tries 5 safe alternatives
- Safe alternatives avoid IME, PowerToys, Language Bar conflicts
- 8 unit tests

## Test plan

- [x] `npm run test` — 84 tests pass
- [x] `npm run build` — zero errors