### PR TITLE
WIN-009: Improve terminal launch compatibility (cmd/PowerShell/WT)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -10,6 +10,7 @@ import { log as _log, LOG_FILE, flushLogs } from './logger'
 import { getProjectSessionKey } from './session-path'
 import { getWindowConfig } from './window-config'
 import { loadShortcutConfig, saveShortcutConfig, getSafeAlternatives } from './shortcut-config'
+import { buildTerminalCommand } from './terminal-launch'
 import { IPC } from '../shared/types'
 import type { RunOptions, NormalizedEvent, EnrichedError } from '../shared/types'
 
@@ -801,29 +802,12 @@ ipcMain.handle(IPC.OPEN_IN_TERMINAL, (_event, arg: string | null | { sessionId?:
     projectPath = arg.projectPath && arg.projectPath !== '~' ? arg.projectPath : process.cwd()
   }
 
-  const baseCmd = sessionId ? `${claudeBin} --resume ${sessionId}` : claudeBin
-  const winCmd = `cd /d "${projectPath}" && ${baseCmd}`
-  const posixCmd = `cd "${projectPath.replace(/"/g, '\\"')}" && ${baseCmd}`
-
   try {
-    if (process.platform === 'darwin') {
-      const escaped = posixCmd.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
-      const script = `tell application "Terminal"\n  activate\n  do script "${escaped}"\nend tell`
-      execFile('/usr/bin/osascript', ['-e', script], (err: Error | null) => {
-        if (err) log(`Failed to open terminal: ${err.message}`)
-        else log(`Opened terminal with: ${posixCmd}`)
-      })
-    } else if (process.platform === 'win32') {
-      execFile('cmd.exe', ['/c', 'start', 'cmd.exe', '/k', winCmd], (err: Error | null) => {
-        if (err) log(`Failed to open terminal: ${err.message}`)
-        else log(`Opened terminal with: ${winCmd}`)
-      })
-    } else {
-      execFile('x-terminal-emulator', ['-e', `bash -lc '${posixCmd.replace(/'/g, `'\\''`)}'`], (err: Error | null) => {
-        if (err) log(`Failed to open terminal: ${err.message}`)
-        else log(`Opened terminal with: ${posixCmd}`)
-      })
-    }
+    const cmd = buildTerminalCommand({ projectPath, claudeBin, sessionId })
+    execFile(cmd.program, cmd.args, (err: Error | null) => {
+      if (err) log(`Failed to open terminal: ${err.message}`)
+      else log(`Opened terminal with: ${cmd.program} ${cmd.args.join(' ')}`)
+    })
     return true
   } catch (err: unknown) {
     log(`Failed to open terminal: ${err}`)

--- a/src/main/terminal-launch.ts
+++ b/src/main/terminal-launch.ts
@@ -1,0 +1,77 @@
+/**
+ * Terminal launch command builder — platform-aware, supports multiple
+ * Windows terminal providers (cmd, PowerShell, Windows Terminal).
+ */
+
+export type WindowsTerminal = 'cmd' | 'powershell' | 'wt'
+
+export interface TerminalCommandOptions {
+  projectPath: string
+  claudeBin: string
+  sessionId?: string | null
+  terminal?: WindowsTerminal
+}
+
+export interface TerminalCommand {
+  program: string
+  args: string[]
+}
+
+export function buildTerminalCommand(options: TerminalCommandOptions): TerminalCommand {
+  const { projectPath, claudeBin, sessionId, terminal } = options
+  const baseCmd = sessionId ? `${claudeBin} --resume ${sessionId}` : claudeBin
+
+  if (process.platform === 'win32') {
+    return buildWindowsCommand(projectPath, baseCmd, terminal || 'cmd')
+  }
+
+  if (process.platform === 'darwin') {
+    return buildDarwinCommand(projectPath, baseCmd)
+  }
+
+  return buildLinuxCommand(projectPath, baseCmd)
+}
+
+function buildWindowsCommand(projectPath: string, baseCmd: string, terminal: WindowsTerminal): TerminalCommand {
+  const cdCmd = `cd /d "${projectPath}" && ${baseCmd}`
+
+  switch (terminal) {
+    case 'powershell':
+      return {
+        program: 'powershell.exe',
+        args: ['-NoExit', '-Command', `Set-Location "${projectPath}"; ${baseCmd}`],
+      }
+
+    case 'wt':
+      return {
+        program: 'wt.exe',
+        args: ['new-tab', '--startingDirectory', projectPath, 'cmd.exe', '/k', baseCmd],
+      }
+
+    case 'cmd':
+    default:
+      return {
+        program: 'cmd.exe',
+        args: ['/c', 'start', 'cmd.exe', '/k', cdCmd],
+      }
+  }
+}
+
+function buildDarwinCommand(projectPath: string, baseCmd: string): TerminalCommand {
+  const posixCmd = `cd "${projectPath.replace(/"/g, '\\"')}" && ${baseCmd}`
+  const escaped = posixCmd.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+  const script = `tell application "Terminal"\n  activate\n  do script "${escaped}"\nend tell`
+
+  return {
+    program: '/usr/bin/osascript',
+    args: ['-e', script],
+  }
+}
+
+function buildLinuxCommand(projectPath: string, baseCmd: string): TerminalCommand {
+  const posixCmd = `cd "${projectPath.replace(/"/g, '\\"')}" && ${baseCmd}`
+  return {
+    program: 'x-terminal-emulator',
+    args: ['-e', `bash -lc '${posixCmd.replace(/'/g, `'\\''`)}'`],
+  }
+}

--- a/tests/unit/terminal-launch.test.ts
+++ b/tests/unit/terminal-launch.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { mockPlatform } from '../helpers/mock-platform'
+import { buildTerminalCommand } from '../../src/main/terminal-launch'
+
+describe('buildTerminalCommand', () => {
+  let restorePlatform: (() => void) | null = null
+
+  afterEach(() => {
+    restorePlatform?.()
+    restorePlatform = null
+  })
+
+  describe('on win32', () => {
+    it('builds cmd.exe command with cd /d', () => {
+      restorePlatform = mockPlatform('win32')
+      const result = buildTerminalCommand({ projectPath: 'C:\\Users\\test\\project', claudeBin: 'claude' })
+
+      expect(result.program).toBe('cmd.exe')
+      expect(result.args.join(' ')).toContain('cd /d')
+    })
+
+    it('handles paths with spaces', () => {
+      restorePlatform = mockPlatform('win32')
+      const result = buildTerminalCommand({ projectPath: 'C:\\Users\\test\\my project', claudeBin: 'claude' })
+
+      expect(result.args.join(' ')).toContain('my project')
+    })
+
+    it('includes resume flag when sessionId provided', () => {
+      restorePlatform = mockPlatform('win32')
+      const result = buildTerminalCommand({ projectPath: 'C:\\test', claudeBin: 'claude', sessionId: 'abc-123' })
+
+      expect(result.args.join(' ')).toContain('--resume abc-123')
+    })
+
+    it('supports powershell provider', () => {
+      restorePlatform = mockPlatform('win32')
+      const result = buildTerminalCommand({ projectPath: 'C:\\test', claudeBin: 'claude', terminal: 'powershell' })
+
+      expect(result.program).toBe('powershell.exe')
+    })
+
+    it('supports windows terminal (wt) provider', () => {
+      restorePlatform = mockPlatform('win32')
+      const result = buildTerminalCommand({ projectPath: 'C:\\test', claudeBin: 'claude', terminal: 'wt' })
+
+      expect(result.program).toBe('wt.exe')
+    })
+  })
+
+  describe('on darwin', () => {
+    it('uses osascript for Terminal.app', () => {
+      restorePlatform = mockPlatform('darwin')
+      const result = buildTerminalCommand({ projectPath: '/Users/test', claudeBin: 'claude' })
+
+      expect(result.program).toBe('/usr/bin/osascript')
+    })
+
+    it('includes session resume in command', () => {
+      restorePlatform = mockPlatform('darwin')
+      const result = buildTerminalCommand({ projectPath: '/tmp', claudeBin: 'claude', sessionId: 'xyz' })
+
+      expect(result.args.join(' ')).toContain('--resume xyz')
+    })
+  })
+
+  describe('on linux', () => {
+    it('uses x-terminal-emulator', () => {
+      restorePlatform = mockPlatform('linux')
+      const result = buildTerminalCommand({ projectPath: '/home/user', claudeBin: 'claude' })
+
+      expect(result.program).toBe('x-terminal-emulator')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Closes #10

- Multi-provider terminal launch: cmd.exe, PowerShell, Windows Terminal
- Extracts inline platform logic into testable `terminal-launch.ts`
- 8 unit tests

## Test plan

- [x] `npm run test` — 95 tests pass
- [x] `npm run build` — zero errors