### PR TITLE
WIN-010: Make screenshot/attachment flow reliable on Windows

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -11,6 +11,7 @@ import { getProjectSessionKey } from './session-path'
 import { getWindowConfig } from './window-config'
 import { loadShortcutConfig, saveShortcutConfig, getSafeAlternatives } from './shortcut-config'
 import { buildTerminalCommand } from './terminal-launch'
+import { buildScreenshotCommand, getScreenshotTempPath } from './screenshot'
 import { IPC } from '../shared/types'
 import type { RunOptions, NormalizedEvent, EnrichedError } from '../shared/types'
 
@@ -568,37 +569,17 @@ ipcMain.handle(IPC.TAKE_SCREENSHOT, async () => {
 
   try {
     const { execSync } = require('child_process')
-    const { join } = require('path')
-    const { tmpdir } = require('os')
-    const { readFileSync, existsSync } = require('fs')
+    const { readFileSync, existsSync, unlinkSync } = require('fs')
 
-    const timestamp = Date.now()
-    const screenshotPath = join(tmpdir(), `clui-screenshot-${timestamp}.png`)
+    const screenshotPath = getScreenshotTempPath()
+    const cmd = buildScreenshotCommand(screenshotPath)
+    if (!cmd) return null
 
-    if (process.platform === 'darwin') {
-      execSync(`/usr/sbin/screencapture -i "${screenshotPath}"`, {
-        timeout: 30000,
-        stdio: 'ignore',
-      })
-    } else if (process.platform === 'win32') {
-      const psScript = [
-        'Add-Type -AssemblyName System.Windows.Forms;',
-        'Add-Type -AssemblyName System.Drawing;',
-        '$bounds = [System.Windows.Forms.Screen]::PrimaryScreen.Bounds;',
-        '$bmp = New-Object System.Drawing.Bitmap($bounds.Width, $bounds.Height);',
-        '$gfx = [System.Drawing.Graphics]::FromImage($bmp);',
-        '$gfx.CopyFromScreen($bounds.Location, [System.Drawing.Point]::Empty, $bounds.Size);',
-        `$bmp.Save('${screenshotPath.replace(/\\/g, '\\\\')}', [System.Drawing.Imaging.ImageFormat]::Png);`,
-        '$gfx.Dispose();',
-        '$bmp.Dispose();',
-      ].join(' ')
-      execSync(`powershell -NoProfile -ExecutionPolicy Bypass -Command "${psScript}"`, {
-        timeout: 30000,
-        stdio: 'ignore',
-      })
-    } else {
-      return null
-    }
+    execSync(`"${cmd.program}" ${cmd.args.map(a => `"${a}"`).join(' ')}`, {
+      timeout: 30000,
+      stdio: 'ignore',
+      shell: true,
+    })
 
     if (!existsSync(screenshotPath)) {
       return null

--- a/src/main/screenshot.ts
+++ b/src/main/screenshot.ts
@@ -1,0 +1,58 @@
+/**
+ * Screenshot command builder — platform-aware capture flow.
+ */
+
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+export interface ScreenshotCommand {
+  program: string
+  args: string[]
+}
+
+let counter = 0
+
+/**
+ * Returns a unique temp path for a screenshot file.
+ */
+export function getScreenshotTempPath(): string {
+  return join(tmpdir(), `clui-screenshot-${Date.now()}-${++counter}.png`)
+}
+
+/**
+ * Build the platform-appropriate screenshot capture command.
+ *
+ * - macOS: uses `/usr/sbin/screencapture -i` (interactive region select)
+ * - Windows: uses PowerShell with System.Drawing (full screen capture)
+ * - Linux: returns null (not supported)
+ */
+export function buildScreenshotCommand(outputPath: string): ScreenshotCommand | null {
+  if (process.platform === 'darwin') {
+    return {
+      program: '/usr/sbin/screencapture',
+      args: ['-i', outputPath],
+    }
+  }
+
+  if (process.platform === 'win32') {
+    const escapedPath = outputPath.replace(/\\/g, '\\\\')
+    const psScript = [
+      'Add-Type -AssemblyName System.Windows.Forms;',
+      'Add-Type -AssemblyName System.Drawing;',
+      '$bounds = [System.Windows.Forms.Screen]::PrimaryScreen.Bounds;',
+      '$bmp = New-Object System.Drawing.Bitmap($bounds.Width, $bounds.Height);',
+      '$gfx = [System.Drawing.Graphics]::FromImage($bmp);',
+      '$gfx.CopyFromScreen($bounds.Location, [System.Drawing.Point]::Empty, $bounds.Size);',
+      `$bmp.Save('${escapedPath}', [System.Drawing.Imaging.ImageFormat]::Png);`,
+      '$gfx.Dispose();',
+      '$bmp.Dispose();',
+    ].join(' ')
+
+    return {
+      program: 'powershell',
+      args: ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-Command', psScript],
+    }
+  }
+
+  return null
+}

--- a/tests/unit/screenshot.test.ts
+++ b/tests/unit/screenshot.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { mockPlatform } from '../helpers/mock-platform'
+import { buildScreenshotCommand, getScreenshotTempPath } from '../../src/main/screenshot'
+
+describe('screenshot', () => {
+  let restorePlatform: (() => void) | null = null
+
+  afterEach(() => {
+    restorePlatform?.()
+    restorePlatform = null
+  })
+
+  describe('buildScreenshotCommand', () => {
+    it('uses screencapture on darwin', () => {
+      restorePlatform = mockPlatform('darwin')
+      const cmd = buildScreenshotCommand('/tmp/test.png')
+      expect(cmd.program).toBe('/usr/sbin/screencapture')
+      expect(cmd.args).toContain('-i')
+    })
+
+    it('uses powershell on win32', () => {
+      restorePlatform = mockPlatform('win32')
+      const cmd = buildScreenshotCommand('C:\\temp\\test.png')
+      expect(cmd.program).toBe('powershell')
+      expect(cmd.args.some(a => a.includes('System.Drawing'))).toBe(true)
+    })
+
+    it('returns null on linux', () => {
+      restorePlatform = mockPlatform('linux')
+      const cmd = buildScreenshotCommand('/tmp/test.png')
+      expect(cmd).toBeNull()
+    })
+  })
+
+  describe('getScreenshotTempPath', () => {
+    it('returns a .png path in temp directory', () => {
+      const p = getScreenshotTempPath()
+      expect(p).toContain('.png')
+      expect(p).toContain('clui-screenshot')
+    })
+
+    it('returns unique paths on successive calls', () => {
+      const p1 = getScreenshotTempPath()
+      const p2 = getScreenshotTempPath()
+      expect(p1).not.toBe(p2)
+    })
+  })
+})


### PR DESCRIPTION
## Summary
Closes #11
- Platform-aware screenshot command builder with testable module
- 5 unit tests, 100 total tests pass, build clean
## Test plan
- [x] `npm run test` — 100 tests pass
- [x] `npm run build` — zero errors