### PR TITLE
FEAT-016: Add shared agent memory coordination

### DIFF
--- a/src/main/agent-memory.ts
+++ b/src/main/agent-memory.ts
@@ -1,0 +1,361 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
+import { dirname } from 'path'
+import type { AgentAssignment, AgentMemorySnapshot, AgentMemoryClaimResult } from '../shared/types'
+
+interface AgentMemoryFile {
+  version: 1
+  projects: Record<string, { active: AgentAssignment[]; recentDone: AgentAssignment[] }>
+}
+
+interface AssignmentInput {
+  tabId: string
+  projectPath: string
+  agentLabel: string
+  summary: string
+  workKey?: string
+}
+
+const MAX_PROMPT_ACTIVE = 8
+const MAX_PROMPT_RECENT = 6
+const DEFAULT_MAX_RECENT_DONE = 12
+const MAX_SUMMARY_LENGTH = 140
+
+export class AgentMemory {
+  private filePath: string
+  private maxRecentDone: number
+
+  constructor(filePath: string, maxRecentDone = DEFAULT_MAX_RECENT_DONE) {
+    this.filePath = filePath
+    this.maxRecentDone = maxRecentDone
+  }
+
+  getSnapshot(projectPath: string): AgentMemorySnapshot {
+    const state = this.readState()
+    const project = this.getProjectState(state, projectPath)
+    return this.cloneSnapshot(projectPath, project)
+  }
+
+  setFocus(input: AssignmentInput): { snapshot: AgentMemorySnapshot; assignment: AgentAssignment } {
+    const state = this.readState()
+    const assignment = this.upsertActiveAssignment(state, input)
+    this.writeState(state)
+    return {
+      snapshot: this.cloneSnapshot(input.projectPath, this.getProjectState(state, input.projectPath)),
+      assignment: { ...assignment },
+    }
+  }
+
+  claim(input: AssignmentInput & { workKey: string }): AgentMemoryClaimResult {
+    const state = this.readState()
+    const project = this.getProjectState(state, input.projectPath)
+    const conflict = project.active.find((item) => item.workKey === input.workKey && item.tabId !== input.tabId)
+
+    if (conflict) {
+      return {
+        ok: false,
+        snapshot: this.cloneSnapshot(input.projectPath, project),
+        conflict: { ...conflict },
+      }
+    }
+
+    const assignment = this.upsertActiveAssignment(state, input)
+    this.writeState(state)
+    return {
+      ok: true,
+      snapshot: this.cloneSnapshot(input.projectPath, this.getProjectState(state, input.projectPath)),
+      assignment: { ...assignment },
+    }
+  }
+
+  markDone(tabId: string, note?: string): { ok: boolean; snapshot: AgentMemorySnapshot | null; assignment?: AgentAssignment } {
+    const state = this.readState()
+    const found = this.findActiveAssignment(state, tabId)
+    if (!found) {
+      return { ok: false, snapshot: null }
+    }
+
+    const now = new Date().toISOString()
+    const completed: AgentAssignment = {
+      ...found.assignment,
+      status: 'done',
+      updatedAt: now,
+      doneAt: now,
+      ...(note?.trim() ? { note: note.trim() } : {}),
+    }
+
+    found.project.active.splice(found.index, 1)
+    found.project.recentDone = [completed, ...found.project.recentDone].slice(0, this.maxRecentDone)
+    this.writeState(state)
+
+    return {
+      ok: true,
+      snapshot: this.cloneSnapshot(found.projectPath, found.project),
+      assignment: completed,
+    }
+  }
+
+  release(tabId: string): { ok: boolean; snapshots: AgentMemorySnapshot[] } {
+    const state = this.readState()
+    const touchedProjects: string[] = []
+
+    for (const [projectPath, project] of Object.entries(state.projects)) {
+      const before = project.active.length
+      project.active = project.active.filter((assignment) => assignment.tabId !== tabId)
+      if (project.active.length !== before) {
+        touchedProjects.push(projectPath)
+      }
+    }
+
+    if (touchedProjects.length === 0) {
+      return { ok: false, snapshots: [] }
+    }
+
+    this.writeState(state)
+
+    return {
+      ok: true,
+      snapshots: touchedProjects.map((projectPath) =>
+        this.cloneSnapshot(projectPath, this.getProjectState(state, projectPath))
+      ),
+    }
+  }
+
+  pruneProject(projectPath: string): AgentMemorySnapshot {
+    const state = this.readState()
+    const project = this.getProjectState(state, projectPath)
+    project.recentDone = project.recentDone.slice(0, this.maxRecentDone)
+    this.writeState(state)
+    return this.cloneSnapshot(projectPath, project)
+  }
+
+  pruneStaleTabs(liveTabIds: Iterable<string>): void {
+    const live = new Set(liveTabIds)
+    const state = this.readState()
+    let changed = false
+
+    for (const project of Object.values(state.projects)) {
+      const before = project.active.length
+      project.active = project.active.filter((assignment) => live.has(assignment.tabId))
+      if (project.active.length !== before) {
+        changed = true
+      }
+      if (project.recentDone.length > this.maxRecentDone) {
+        project.recentDone = project.recentDone.slice(0, this.maxRecentDone)
+        changed = true
+      }
+    }
+
+    if (changed) {
+      this.writeState(state)
+    }
+  }
+
+  buildPromptContext(projectPath: string, currentTabId: string): string {
+    const snapshot = this.getSnapshot(projectPath)
+    const current = snapshot.active.find((item) => item.tabId === currentTabId)
+    const otherActive = snapshot.active
+      .filter((item) => item.tabId !== currentTabId)
+      .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
+      .slice(0, MAX_PROMPT_ACTIVE)
+    const recentDone = snapshot.recentDone
+      .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
+      .slice(0, MAX_PROMPT_RECENT)
+
+    if (!current && otherActive.length === 0 && recentDone.length === 0) {
+      return ''
+    }
+
+    const lines: string[] = ['Shared agent memory for this project:']
+
+    if (current) {
+      lines.push(`Current assignment: ${formatAssignment(current)}`)
+    }
+
+    if (otherActive.length > 0) {
+      lines.push('Other active work:')
+      for (const assignment of otherActive) {
+        lines.push(`- ${formatAssignment(assignment)}`)
+      }
+    }
+
+    if (recentDone.length > 0) {
+      lines.push('Recent completed work:')
+      for (const assignment of recentDone) {
+        lines.push(`- ${formatDoneAssignment(assignment)}`)
+      }
+    }
+
+    return lines.join('\n')
+  }
+
+  private upsertActiveAssignment(state: AgentMemoryFile, input: AssignmentInput): AgentAssignment {
+    const now = new Date().toISOString()
+    const project = this.getProjectState(state, input.projectPath)
+    const previous = this.findActiveAssignment(state, input.tabId)?.assignment
+
+    this.removeActiveAssignmentsForTab(state, input.tabId)
+
+    const assignment: AgentAssignment = {
+      tabId: input.tabId,
+      agentLabel: sanitizeText(input.agentLabel, 48) || `Tab ${input.tabId.slice(0, 8)}`,
+      projectPath: input.projectPath,
+      ...(input.workKey ? { workKey: sanitizeText(input.workKey, 80) } : {}),
+      summary: sanitizeText(input.summary, MAX_SUMMARY_LENGTH),
+      status: 'active',
+      startedAt: previous?.startedAt ?? now,
+      updatedAt: now,
+    }
+
+    project.active = [assignment, ...project.active]
+      .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
+
+    return assignment
+  }
+
+  private findActiveAssignment(state: AgentMemoryFile, tabId: string): {
+    projectPath: string
+    project: { active: AgentAssignment[]; recentDone: AgentAssignment[] }
+    assignment: AgentAssignment
+    index: number
+  } | null {
+    for (const [projectPath, project] of Object.entries(state.projects)) {
+      const index = project.active.findIndex((assignment) => assignment.tabId === tabId)
+      if (index !== -1) {
+        return {
+          projectPath,
+          project,
+          assignment: project.active[index],
+          index,
+        }
+      }
+    }
+
+    return null
+  }
+
+  private removeActiveAssignmentsForTab(state: AgentMemoryFile, tabId: string): void {
+    for (const project of Object.values(state.projects)) {
+      project.active = project.active.filter((assignment) => assignment.tabId !== tabId)
+    }
+  }
+
+  private readState(): AgentMemoryFile {
+    try {
+      if (!existsSync(this.filePath)) {
+        return defaultState()
+      }
+
+      const raw = readFileSync(this.filePath, 'utf-8')
+      const parsed = JSON.parse(raw)
+      const projects: AgentMemoryFile['projects'] = {}
+
+      if (parsed?.projects && typeof parsed.projects === 'object') {
+        for (const [projectPath, value] of Object.entries(parsed.projects as Record<string, any>)) {
+          projects[projectPath] = {
+            active: normalizeAssignments(value?.active, projectPath, 'active'),
+            recentDone: normalizeAssignments(value?.recentDone, projectPath, 'done').slice(0, this.maxRecentDone),
+          }
+        }
+      }
+
+      return { version: 1, projects }
+    } catch {
+      return defaultState()
+    }
+  }
+
+  private writeState(state: AgentMemoryFile): void {
+    const dir = dirname(this.filePath)
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true })
+    }
+
+    writeFileSync(this.filePath, JSON.stringify(state, null, 2), 'utf-8')
+  }
+
+  private getProjectState(state: AgentMemoryFile, projectPath: string): { active: AgentAssignment[]; recentDone: AgentAssignment[] } {
+    if (!state.projects[projectPath]) {
+      state.projects[projectPath] = { active: [], recentDone: [] }
+    }
+
+    return state.projects[projectPath]
+  }
+
+  private cloneSnapshot(projectPath: string, project: { active: AgentAssignment[]; recentDone: AgentAssignment[] }): AgentMemorySnapshot {
+    return {
+      projectPath,
+      active: project.active.map((assignment) => ({ ...assignment })),
+      recentDone: project.recentDone.map((assignment) => ({ ...assignment })),
+    }
+  }
+}
+
+function defaultState(): AgentMemoryFile {
+  return {
+    version: 1,
+    projects: {},
+  }
+}
+
+function normalizeAssignments(value: unknown, projectPath: string, fallbackStatus: 'active' | 'done'): AgentAssignment[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value.flatMap((entry) => {
+    if (!entry || typeof entry !== 'object') {
+      return []
+    }
+
+    const raw = entry as Partial<AgentAssignment>
+    if (typeof raw.tabId !== 'string' || typeof raw.summary !== 'string') {
+      return []
+    }
+
+    const startedAt = typeof raw.startedAt === 'string' ? raw.startedAt : new Date().toISOString()
+    const updatedAt = typeof raw.updatedAt === 'string' ? raw.updatedAt : startedAt
+    const status = raw.status === 'active' || raw.status === 'done' ? raw.status : fallbackStatus
+
+    return [{
+      tabId: raw.tabId,
+      agentLabel: typeof raw.agentLabel === 'string' && raw.agentLabel.trim().length > 0
+        ? sanitizeText(raw.agentLabel, 48)
+        : `Tab ${raw.tabId.slice(0, 8)}`,
+      projectPath,
+      ...(typeof raw.workKey === 'string' && raw.workKey.trim().length > 0
+        ? { workKey: sanitizeText(raw.workKey, 80) }
+        : {}),
+      summary: sanitizeText(raw.summary, MAX_SUMMARY_LENGTH),
+      status,
+      startedAt,
+      updatedAt,
+      ...(typeof raw.doneAt === 'string' ? { doneAt: raw.doneAt } : {}),
+      ...(typeof raw.note === 'string' && raw.note.trim().length > 0
+        ? { note: sanitizeText(raw.note, MAX_SUMMARY_LENGTH) }
+        : {}),
+    }]
+  })
+}
+
+function sanitizeText(value: string, maxLength: number): string {
+  const normalized = value.replace(/\s+/g, ' ').trim()
+  if (normalized.length <= maxLength) {
+    return normalized
+  }
+  return `${normalized.slice(0, maxLength - 1).trimEnd()}…`
+}
+
+function formatAssignment(assignment: AgentAssignment): string {
+  const prefix = assignment.workKey
+    ? `${assignment.workKey} -> ${assignment.agentLabel}`
+    : assignment.agentLabel
+  return `${prefix}: ${assignment.summary}`
+}
+
+function formatDoneAssignment(assignment: AgentAssignment): string {
+  const base = formatAssignment(assignment)
+  if (!assignment.note) {
+    return base
+  }
+  return `${base} (${assignment.note})`
+}

--- a/src/main/claude/control-plane.ts
+++ b/src/main/claude/control-plane.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from 'events'
 import { RunManager } from './run-manager'
 import { PtyRunManager } from './pty-run-manager'
 import { PermissionServer, maskSensitiveFields } from '../hooks/permission-server'
+import { AgentMemory } from '../agent-memory'
 import type { HookToolRequest, PermissionOption } from '../hooks/permission-server'
 import { log as _log } from '../logger'
 import type {
@@ -11,6 +12,8 @@ import type {
   NormalizedEvent,
   RunOptions,
   EnrichedError,
+  AgentMemorySnapshot,
+  AgentMemoryClaimResult,
 } from '../../shared/types'
 
 const MAX_QUEUE_DEPTH = 32
@@ -75,6 +78,8 @@ export class ControlPlane extends EventEmitter {
   private permissionMode: 'ask' | 'auto' = 'ask'
   /** Resolves when the permission server is ready (or failed). Dispatch awaits this. */
   private hookServerReady: Promise<void>
+  /** Optional persisted coordination memory shared across tabs/agents. */
+  private agentMemory: AgentMemory | null = null
 
   constructor(interactivePty = false) {
     super()
@@ -289,6 +294,11 @@ export class ControlPlane extends EventEmitter {
         this.inflightRequests.delete(requestId)
       }
     })
+  }
+
+  setAgentMemory(agentMemory: AgentMemory): void {
+    this.agentMemory = agentMemory
+    this.agentMemory.pruneStaleTabs(this.tabs.keys())
   }
 
   /**
@@ -528,7 +538,72 @@ export class ControlPlane extends EventEmitter {
     })
 
     this.tabs.delete(tabId)
+    this.agentMemory?.pruneStaleTabs(this.tabs.keys())
     log(`Tab closed: ${tabId}`)
+  }
+
+  getAgentMemorySnapshot(projectPath: string): AgentMemorySnapshot {
+    this.agentMemory?.pruneStaleTabs(this.tabs.keys())
+    return this.agentMemory?.getSnapshot(projectPath) ?? {
+      projectPath,
+      active: [],
+      recentDone: [],
+    }
+  }
+
+  setAgentFocus(tabId: string, projectPath: string, agentLabel: string, summary: string): {
+    snapshot: AgentMemorySnapshot
+    assignment?: AgentMemorySnapshot['active'][number]
+  } {
+    this.agentMemory?.pruneStaleTabs(this.tabs.keys())
+    if (!this.agentMemory) {
+      return { snapshot: { projectPath, active: [], recentDone: [] } }
+    }
+    return this.agentMemory.setFocus({ tabId, projectPath, agentLabel, summary })
+  }
+
+  claimAgentWork(
+    tabId: string,
+    projectPath: string,
+    agentLabel: string,
+    workKey: string,
+    summary: string,
+  ): AgentMemoryClaimResult {
+    this.agentMemory?.pruneStaleTabs(this.tabs.keys())
+    if (!this.agentMemory) {
+      return {
+        ok: true,
+        snapshot: { projectPath, active: [], recentDone: [] },
+        assignment: {
+          tabId,
+          agentLabel,
+          projectPath,
+          workKey,
+          summary,
+          status: 'active',
+          startedAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+      }
+    }
+    return this.agentMemory.claim({ tabId, projectPath, agentLabel, workKey, summary })
+  }
+
+  markAgentDone(tabId: string, note?: string): { ok: boolean; snapshot: AgentMemorySnapshot | null } {
+    this.agentMemory?.pruneStaleTabs(this.tabs.keys())
+    if (!this.agentMemory) {
+      return { ok: false, snapshot: null }
+    }
+    const result = this.agentMemory.markDone(tabId, note)
+    return { ok: result.ok, snapshot: result.snapshot }
+  }
+
+  releaseAgentWork(tabId: string): { ok: boolean; snapshots: AgentMemorySnapshot[] } {
+    this.agentMemory?.pruneStaleTabs(this.tabs.keys())
+    if (!this.agentMemory) {
+      return { ok: false, snapshots: [] }
+    }
+    return this.agentMemory.release(tabId)
   }
 
   // ─── Submit Prompt ───
@@ -607,6 +682,17 @@ export class ControlPlane extends EventEmitter {
     // Use stored session ID for resume if available and not overridden
     if (tab.claudeSessionId && !options.sessionId) {
       options = { ...options, sessionId: tab.claudeSessionId }
+    }
+
+    if (this.agentMemory) {
+      this.agentMemory.pruneStaleTabs(this.tabs.keys())
+      const agentMemoryPrompt = this.agentMemory.buildPromptContext(options.projectPath, tabId)
+      if (agentMemoryPrompt) {
+        options = {
+          ...options,
+          systemPrompt: [options.systemPrompt, agentMemoryPrompt].filter(Boolean).join('\n\n'),
+        }
+      }
     }
 
     // Per-run token lifecycle: register run, generate per-run settings file

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -13,6 +13,7 @@ import { loadShortcutConfig, saveShortcutConfig, getSafeAlternatives } from './s
 import { buildTerminalCommand } from './terminal-launch'
 import { buildScreenshotCommand, getScreenshotTempPath } from './screenshot'
 import { SettingsManager } from './settings-manager'
+import { AgentMemory } from './agent-memory'
 import { IPC } from '../shared/types'
 import type { RunOptions, NormalizedEvent, EnrichedError } from '../shared/types'
 
@@ -32,6 +33,7 @@ let toggleSequence = 0
 const INTERACTIVE_PTY = process.env.CLUI_INTERACTIVE_PERMISSIONS_PTY === '1'
 
 const settingsManager = new SettingsManager()
+let agentMemory: AgentMemory | null = null
 
 const controlPlane = new ControlPlane(INTERACTIVE_PTY)
 
@@ -485,6 +487,48 @@ ipcMain.handle(IPC.LOAD_SESSION, async (_e, arg: { sessionId: string; projectPat
   }
 })
 
+ipcMain.handle(IPC.AGENT_MEMORY_GET, (_event, projectPath: string) => {
+  log(`IPC AGENT_MEMORY_GET: ${projectPath}`)
+  return controlPlane.getAgentMemorySnapshot(projectPath)
+})
+
+ipcMain.handle(
+  IPC.AGENT_MEMORY_FOCUS,
+  (_event, { tabId, projectPath, agentLabel, summary }: {
+    tabId: string
+    projectPath: string
+    agentLabel: string
+    summary: string
+  }) => {
+    log(`IPC AGENT_MEMORY_FOCUS: tab=${tabId} project=${projectPath}`)
+    return controlPlane.setAgentFocus(tabId, projectPath, agentLabel, summary)
+  }
+)
+
+ipcMain.handle(
+  IPC.AGENT_MEMORY_CLAIM,
+  (_event, { tabId, projectPath, agentLabel, workKey, summary }: {
+    tabId: string
+    projectPath: string
+    agentLabel: string
+    workKey: string
+    summary: string
+  }) => {
+    log(`IPC AGENT_MEMORY_CLAIM: tab=${tabId} key=${workKey}`)
+    return controlPlane.claimAgentWork(tabId, projectPath, agentLabel, workKey, summary)
+  }
+)
+
+ipcMain.handle(IPC.AGENT_MEMORY_DONE, (_event, { tabId, note }: { tabId: string; note?: string }) => {
+  log(`IPC AGENT_MEMORY_DONE: tab=${tabId}`)
+  return controlPlane.markAgentDone(tabId, note)
+})
+
+ipcMain.handle(IPC.AGENT_MEMORY_RELEASE, (_event, tabId: string) => {
+  log(`IPC AGENT_MEMORY_RELEASE: tab=${tabId}`)
+  return controlPlane.releaseAgentWork(tabId)
+})
+
 ipcMain.handle(IPC.SELECT_DIRECTORY, async () => {
   if (!mainWindow) return null
   // macOS: activate app so unparented dialog appears on top (not behind other apps).
@@ -871,6 +915,9 @@ nativeTheme.on('updated', () => {
 // ─── App Lifecycle ───
 
 app.whenReady().then(() => {
+  agentMemory = new AgentMemory(join(app.getPath('userData'), 'agent-memory.json'))
+  controlPlane.setAgentMemory(agentMemory)
+
   // macOS: become an accessory app. Accessory apps can have key windows (keyboard works)
   // without deactivating the currently active app (hover preserved in browsers).
   // This is how Spotlight, Alfred, Raycast work.

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -9,6 +9,8 @@ import type {
   SessionMeta,
   CatalogPlugin,
   SessionLoadMessage,
+  AgentMemorySnapshot,
+  AgentMemoryClaimResult,
 } from '../shared/types'
 
 export interface CluiAPI {
@@ -35,6 +37,11 @@ export interface CluiAPI {
   resetTabSession(tabId: string): void
   listSessions(projectPath?: string): Promise<SessionMeta[]>
   loadSession(sessionId: string, projectPath?: string): Promise<SessionLoadMessage[]>
+  agentMemoryGet(projectPath: string): Promise<AgentMemorySnapshot>
+  agentMemoryFocus(tabId: string, projectPath: string, agentLabel: string, summary: string): Promise<{ snapshot: AgentMemorySnapshot }>
+  agentMemoryClaim(tabId: string, projectPath: string, agentLabel: string, workKey: string, summary: string): Promise<AgentMemoryClaimResult>
+  agentMemoryDone(tabId: string, note?: string): Promise<{ ok: boolean; snapshot: AgentMemorySnapshot | null }>
+  agentMemoryRelease(tabId: string): Promise<{ ok: boolean; snapshots: AgentMemorySnapshot[] }>
   fetchMarketplace(forceRefresh?: boolean): Promise<{ plugins: CatalogPlugin[]; error: string | null }>
   listInstalledPlugins(): Promise<string[]>
   installPlugin(repo: string, pluginName: string, marketplace: string, sourcePath?: string, isSkillMd?: boolean): Promise<{ ok: boolean; error?: string }>
@@ -91,6 +98,13 @@ const api: CluiAPI = {
   resetTabSession: (tabId) => ipcRenderer.send(IPC.RESET_TAB_SESSION, tabId),
   listSessions: (projectPath?: string) => ipcRenderer.invoke(IPC.LIST_SESSIONS, projectPath),
   loadSession: (sessionId: string, projectPath?: string) => ipcRenderer.invoke(IPC.LOAD_SESSION, { sessionId, projectPath }),
+  agentMemoryGet: (projectPath) => ipcRenderer.invoke(IPC.AGENT_MEMORY_GET, projectPath),
+  agentMemoryFocus: (tabId, projectPath, agentLabel, summary) =>
+    ipcRenderer.invoke(IPC.AGENT_MEMORY_FOCUS, { tabId, projectPath, agentLabel, summary }),
+  agentMemoryClaim: (tabId, projectPath, agentLabel, workKey, summary) =>
+    ipcRenderer.invoke(IPC.AGENT_MEMORY_CLAIM, { tabId, projectPath, agentLabel, workKey, summary }),
+  agentMemoryDone: (tabId, note) => ipcRenderer.invoke(IPC.AGENT_MEMORY_DONE, { tabId, note }),
+  agentMemoryRelease: (tabId) => ipcRenderer.invoke(IPC.AGENT_MEMORY_RELEASE, tabId),
   fetchMarketplace: (forceRefresh) => ipcRenderer.invoke(IPC.MARKETPLACE_FETCH, { forceRefresh }),
   listInstalledPlugins: () => ipcRenderer.invoke(IPC.MARKETPLACE_INSTALLED),
   installPlugin: (repo, pluginName, marketplace, sourcePath, isSkillMd) =>

--- a/src/renderer/components/InputBar.tsx
+++ b/src/renderer/components/InputBar.tsx
@@ -5,6 +5,7 @@ import { useSessionStore, AVAILABLE_MODELS } from '../stores/sessionStore'
 import { AttachmentChips } from './AttachmentChips'
 import { SlashCommandMenu, getFilteredCommandsWithExtras, type SlashCommand } from './SlashCommandMenu'
 import { useColors } from '../theme'
+import type { AgentAssignment, AgentMemorySnapshot } from '../../shared/types'
 
 const INPUT_MIN_HEIGHT = 20
 const INPUT_MAX_HEIGHT = 140
@@ -13,6 +14,42 @@ const MULTILINE_EXIT_HEIGHT = 50
 const INLINE_CONTROLS_RESERVED_WIDTH = 104
 
 type VoiceState = 'idle' | 'recording' | 'transcribing'
+
+function formatAssignmentLine(assignment: AgentAssignment): string {
+  const prefix = assignment.workKey ? `${assignment.workKey} -> ${assignment.agentLabel}` : assignment.agentLabel
+  return `${prefix}: ${assignment.summary}`
+}
+
+function formatMemorySnapshot(snapshot: AgentMemorySnapshot | null, activeTabId: string): string {
+  if (!snapshot || (snapshot.active.length === 0 && snapshot.recentDone.length === 0)) {
+    return 'No shared agent memory for this project yet.'
+  }
+
+  const lines: string[] = []
+  const current = snapshot.active.find((assignment) => assignment.tabId === activeTabId)
+  const otherActive = snapshot.active.filter((assignment) => assignment.tabId !== activeTabId)
+
+  if (current) {
+    lines.push(`Current: ${formatAssignmentLine(current)}`)
+  }
+
+  if (otherActive.length > 0) {
+    lines.push('Active:')
+    for (const assignment of otherActive) {
+      lines.push(`- ${formatAssignmentLine(assignment)}`)
+    }
+  }
+
+  if (snapshot.recentDone.length > 0) {
+    lines.push('Recent done:')
+    for (const assignment of snapshot.recentDone) {
+      const line = formatAssignmentLine(assignment)
+      lines.push(`- ${assignment.note ? `${line} (${assignment.note})` : line}`)
+    }
+  }
+
+  return lines.join('\n')
+}
 
 /**
  * InputBar renders inside a glass-surface rounded-full pill provided by App.tsx.
@@ -36,9 +73,15 @@ export function InputBar() {
   const addSystemMessage = useSessionStore((s) => s.addSystemMessage)
   const addAttachments = useSessionStore((s) => s.addAttachments)
   const removeAttachment = useSessionStore((s) => s.removeAttachment)
+  const refreshAgentMemory = useSessionStore((s) => s.refreshAgentMemory)
+  const setAgentFocus = useSessionStore((s) => s.setAgentFocus)
+  const claimAgentWork = useSessionStore((s) => s.claimAgentWork)
+  const markAgentDone = useSessionStore((s) => s.markAgentDone)
+  const releaseAgentWork = useSessionStore((s) => s.releaseAgentWork)
 
   const setPreferredModel = useSessionStore((s) => s.setPreferredModel)
   const staticInfo = useSessionStore((s) => s.staticInfo)
+  const agentMemorySnapshot = useSessionStore((s) => s.agentMemorySnapshot)
   const preferredModel = useSessionStore((s) => s.preferredModel)
   const activeTabId = useSessionStore((s) => s.activeTabId)
   const tab = useSessionStore((s) => s.tabs.find((t) => t.id === s.activeTabId))
@@ -164,6 +207,11 @@ export function InputBar() {
         clearTab()
         addSystemMessage('Conversation cleared.')
         break
+      case '/memory':
+        void refreshAgentMemory().then((snapshot) => {
+          addSystemMessage(formatMemorySnapshot(snapshot || agentMemorySnapshot, activeTabId))
+        })
+        break
       case '/cost': {
         if (tab?.lastResult) {
           const r = tab.lastResult
@@ -227,11 +275,11 @@ export function InputBar() {
         break
       }
     }
-  }, [tab, clearTab, addSystemMessage, staticInfo, preferredModel])
+  }, [tab, clearTab, addSystemMessage, staticInfo, preferredModel, refreshAgentMemory, agentMemorySnapshot, activeTabId])
 
   const handleSlashSelect = useCallback((cmd: SlashCommand) => {
     const isSkillCommand = !!tab?.sessionSkills?.includes(cmd.command.replace(/^\//, ''))
-    if (isSkillCommand) {
+    if (isSkillCommand || cmd.insertOnly) {
       setInput(`${cmd.command} `)
       setSlashFilter(null)
       requestAnimationFrame(() => textareaRef.current?.focus())
@@ -243,7 +291,7 @@ export function InputBar() {
   }, [executeCommand, tab?.sessionSkills])
 
   // ─── Send ───
-  const handleSend = useCallback(() => {
+  const handleSend = useCallback(async () => {
     if (showSlashMenu) {
       const filtered = getFilteredCommandsWithExtras(slashFilter!, skillCommands)
       if (filtered.length > 0) {
@@ -252,6 +300,63 @@ export function InputBar() {
       }
     }
     const prompt = input.trim()
+    const clearComposer = () => {
+      setInput('')
+      setSlashFilter(null)
+      if (textareaRef.current) {
+        textareaRef.current.style.height = `${INPUT_MIN_HEIGHT}px`
+      }
+    }
+
+    const focusMatch = prompt.match(/^\/focus\s+(.+)/i)
+    if (focusMatch) {
+      clearComposer()
+      const assignment = await setAgentFocus(focusMatch[1].trim()).catch(() => null)
+      addSystemMessage(assignment ? `Focus set: ${formatAssignmentLine(assignment)}` : 'Failed to update shared memory focus.')
+      requestAnimationFrame(() => textareaRef.current?.focus())
+      return
+    }
+
+    const claimMatch = prompt.match(/^\/claim\s+(\S+)\s+(.+)/i)
+    if (claimMatch) {
+      clearComposer()
+      const result = await claimAgentWork(claimMatch[1], claimMatch[2].trim()).catch(() => null)
+      if (!result) {
+        addSystemMessage('Failed to claim shared work item.')
+      } else if (result.ok) {
+        addSystemMessage(`Claimed: ${formatAssignmentLine(result.assignment)}`)
+      } else {
+        addSystemMessage(`Claim conflict: ${formatAssignmentLine(result.conflict)}`)
+      }
+      requestAnimationFrame(() => textareaRef.current?.focus())
+      return
+    }
+
+    const doneMatch = prompt.match(/^\/done(?:\s+(.+))?$/i)
+    if (doneMatch) {
+      clearComposer()
+      const ok = await markAgentDone(doneMatch[1]?.trim()).catch(() => false)
+      addSystemMessage(ok ? 'Marked current work as done.' : 'No active work assignment to mark as done.')
+      requestAnimationFrame(() => textareaRef.current?.focus())
+      return
+    }
+
+    if (/^\/release$/i.test(prompt)) {
+      clearComposer()
+      const ok = await releaseAgentWork().catch(() => false)
+      addSystemMessage(ok ? 'Released current work assignment.' : 'No active work assignment to release.')
+      requestAnimationFrame(() => textareaRef.current?.focus())
+      return
+    }
+
+    if (/^\/memory$/i.test(prompt)) {
+      clearComposer()
+      const snapshot = await refreshAgentMemory().catch(() => null)
+      addSystemMessage(formatMemorySnapshot(snapshot || agentMemorySnapshot, activeTabId))
+      requestAnimationFrame(() => textareaRef.current?.focus())
+      return
+    }
+
     const modelMatch = prompt.match(/^\/model\s+(\S+)/i)
     if (modelMatch) {
       const query = modelMatch[1].toLowerCase()
@@ -260,27 +365,39 @@ export function InputBar() {
       )
       if (match) {
         setPreferredModel(match.id)
-        setInput('')
-        setSlashFilter(null)
+        clearComposer()
         addSystemMessage(`Model switched to ${match.label} (${match.id})`)
       } else {
-        setInput('')
-        setSlashFilter(null)
+        clearComposer()
         addSystemMessage(`Unknown model "${modelMatch[1]}". Available: opus, sonnet, haiku`)
       }
       return
     }
     if (!prompt && attachments.length === 0) return
     if (isConnecting) return
-    setInput('')
-    setSlashFilter(null)
-    if (textareaRef.current) {
-      textareaRef.current.style.height = `${INPUT_MIN_HEIGHT}px`
-    }
+    clearComposer()
     sendMessage(prompt || 'See attached files')
     // Refocus after React re-renders from the state update
     requestAnimationFrame(() => textareaRef.current?.focus())
-  }, [input, isBusy, sendMessage, attachments.length, showSlashMenu, slashFilter, slashIndex, handleSlashSelect])
+  }, [
+    input,
+    sendMessage,
+    attachments.length,
+    showSlashMenu,
+    slashFilter,
+    slashIndex,
+    handleSlashSelect,
+    isConnecting,
+    setPreferredModel,
+    setAgentFocus,
+    claimAgentWork,
+    markAgentDone,
+    releaseAgentWork,
+    refreshAgentMemory,
+    agentMemorySnapshot,
+    activeTabId,
+    addSystemMessage,
+  ])
 
   // ─── Keyboard ───
   const handleKeyDown = (e: React.KeyboardEvent) => {

--- a/src/renderer/components/SlashCommandMenu.tsx
+++ b/src/renderer/components/SlashCommandMenu.tsx
@@ -11,10 +11,16 @@ export interface SlashCommand {
   command: string
   description: string
   icon: React.ReactNode
+  insertOnly?: boolean
 }
 
 export const SLASH_COMMANDS: SlashCommand[] = [
   { command: '/clear', description: 'Clear conversation history', icon: <Trash size={13} /> },
+  { command: '/focus', description: 'Set the current work focus', icon: <Sparkle size={13} />, insertOnly: true },
+  { command: '/claim', description: 'Claim a work item by key', icon: <HardDrives size={13} />, insertOnly: true },
+  { command: '/done', description: 'Mark the current work as done', icon: <Question size={13} />, insertOnly: true },
+  { command: '/release', description: 'Release the current claim', icon: <Trash size={13} />, insertOnly: true },
+  { command: '/memory', description: 'Show active and recent shared work', icon: <HardDrives size={13} /> },
   { command: '/cost', description: 'Show token usage and cost', icon: <CurrencyDollar size={13} /> },
   { command: '/model', description: 'Show current model info', icon: <Cpu size={13} /> },
   { command: '/mcp', description: 'Show MCP server status', icon: <HardDrives size={13} /> },

--- a/src/renderer/components/StatusBar.tsx
+++ b/src/renderer/components/StatusBar.tsx
@@ -257,6 +257,18 @@ function compactPath(fullPath: string): string {
   return parts[parts.length - 1] || fullPath
 }
 
+function compactAssignmentLabel(assignment: NonNullable<ReturnType<typeof useSessionStore.getState>['tabs'][number]['agentAssignment']>): string {
+  const base = assignment.workKey
+    ? `${assignment.workKey}: ${assignment.summary}`
+    : assignment.summary
+
+  if (base.length <= 44) {
+    return base
+  }
+
+  return `${base.slice(0, 43).trimEnd()}…`
+}
+
 export function StatusBar() {
   const tab = useSessionStore(
     (s) => s.tabs.find((t) => t.id === s.activeTabId),
@@ -266,6 +278,9 @@ export function StatusBar() {
       && a.hasChosenDirectory === b.hasChosenDirectory
       && a.workingDirectory === b.workingDirectory
       && a.claudeSessionId === b.claudeSessionId
+      && a.agentAssignment?.updatedAt === b.agentAssignment?.updatedAt
+      && a.agentAssignment?.summary === b.agentAssignment?.summary
+      && a.agentAssignment?.workKey === b.agentAssignment?.workKey
     ),
   )
   const addDirectory = useSessionStore((s) => s.addDirectory)
@@ -434,6 +449,25 @@ export function StatusBar() {
         <span style={{ color: colors.textMuted, fontSize: 10 }}>|</span>
 
         <PermissionModePicker />
+
+        {tab.agentAssignment && (
+          <>
+            <span style={{ color: colors.textMuted, fontSize: 10 }}>|</span>
+            <span
+              className="max-w-[220px] truncate rounded-full px-1.5 py-0.5 text-[10px]"
+              style={{
+                color: colors.textSecondary,
+                background: colors.accentLight,
+                border: `1px solid ${colors.accentBorder}`,
+              }}
+              title={tab.agentAssignment.workKey
+                ? `${tab.agentAssignment.workKey}\n${tab.agentAssignment.summary}`
+                : tab.agentAssignment.summary}
+            >
+              {compactAssignmentLabel(tab.agentAssignment)}
+            </span>
+          </>
+        )}
       </div>
 
       {/* Right — Open in CLI */}

--- a/src/renderer/stores/sessionStore.ts
+++ b/src/renderer/stores/sessionStore.ts
@@ -1,5 +1,18 @@
 import { create } from 'zustand'
-import type { TabStatus, NormalizedEvent, EnrichedError, Message, TabState, Attachment, CatalogPlugin, PluginStatus, RunOptions } from '../../shared/types'
+import type {
+  TabStatus,
+  NormalizedEvent,
+  EnrichedError,
+  Message,
+  TabState,
+  Attachment,
+  CatalogPlugin,
+  PluginStatus,
+  RunOptions,
+  AgentAssignment,
+  AgentMemorySnapshot,
+  AgentMemoryClaimResult,
+} from '../../shared/types'
 import { canScheduleAutoResume, DEFAULT_AUTO_RESUME_MAX_RETRIES, getAutoResumeDelayMs } from '../../shared/retry-policy'
 import { useThemeStore } from '../theme'
 import notificationSrc from '../../../resources/notification.mp3'
@@ -29,6 +42,7 @@ interface State {
   isExpanded: boolean
   /** Global info fetched on startup (not per-session) */
   staticInfo: StaticInfo | null
+  agentMemorySnapshot: AgentMemorySnapshot | null
   /** User's preferred model override (null = use default) */
   preferredModel: string | null
   /** Global permission mode: 'ask' shows cards, 'auto' auto-approves all tool calls */
@@ -71,6 +85,11 @@ interface State {
   addAttachments: (attachments: Attachment[]) => void
   removeAttachment: (attachmentId: string) => void
   clearAttachments: () => void
+  refreshAgentMemory: (projectPath?: string) => Promise<AgentMemorySnapshot | null>
+  setAgentFocus: (summary: string) => Promise<AgentAssignment | null>
+  claimAgentWork: (workKey: string, summary: string) => Promise<AgentMemoryClaimResult | null>
+  markAgentDone: (note?: string) => Promise<boolean>
+  releaseAgentWork: () => Promise<boolean>
   retryTab: (tabId: string) => void
   stopRetrying: (tabId: string) => void
   handleNormalizedEvent: (tabId: string, event: NormalizedEvent) => void
@@ -88,6 +107,51 @@ function clearRetryTimer(tabId: string) {
     clearTimeout(timer)
     retryTimers.delete(tabId)
   }
+}
+
+function getResolvedProjectPath(tab: TabState | undefined, staticInfo: StaticInfo | null): string {
+  if (!tab) {
+    return staticInfo?.homePath || '~'
+  }
+
+  return tab.hasChosenDirectory
+    ? tab.workingDirectory
+    : (staticInfo?.homePath || tab.workingDirectory || '~')
+}
+
+function getAgentLabel(tabId: string, tabs: TabState[]): string {
+  const index = tabs.findIndex((tab) => tab.id === tabId)
+  return index === -1 ? `Tab ${tabId.slice(0, 8)}` : `Tab ${index + 1}`
+}
+
+function inferFocusSummary(prompt: string): string {
+  const normalized = prompt.replace(/\s+/g, ' ').trim()
+  if (normalized.length <= 120) {
+    return normalized
+  }
+  return `${normalized.slice(0, 119).trimEnd()}…`
+}
+
+function applyAgentMemorySnapshotToTabs(
+  tabs: TabState[],
+  snapshot: AgentMemorySnapshot | null,
+  staticInfo: StaticInfo | null,
+): TabState[] {
+  if (!snapshot) {
+    return tabs
+  }
+
+  return tabs.map((tab) => {
+    const tabProjectPath = getResolvedProjectPath(tab, staticInfo)
+    if (tabProjectPath !== snapshot.projectPath) {
+      return tab
+    }
+
+    return {
+      ...tab,
+      agentAssignment: snapshot.active.find((assignment) => assignment.tabId === tab.id) || null,
+    }
+  })
 }
 
 // ─── Notification sound (plays when task completes while window is hidden) ───
@@ -116,6 +180,7 @@ function makeLocalTab(): TabState {
     permissionQueue: [],
     permissionDenied: null,
     retryState: null,
+    agentAssignment: null,
     lastRunOptions: null,
     queuedRunOptions: [],
     attachments: [],
@@ -141,6 +206,7 @@ export const useSessionStore = create<State>((set, get) => ({
   activeTabId: initialTab.id,
   isExpanded: false,
   staticInfo: null,
+  agentMemorySnapshot: null,
   preferredModel: null,
   permissionMode: 'ask',
 
@@ -166,6 +232,7 @@ export const useSessionStore = create<State>((set, get) => ({
           homePath: result.homePath || '~',
         },
       })
+      void get().refreshAgentMemory(result.projectPath || result.homePath || '~')
     } catch {}
   },
 
@@ -180,6 +247,7 @@ export const useSessionStore = create<State>((set, get) => ({
 
   createTab: async () => {
     const homeDir = get().staticInfo?.homePath || '~'
+    const defaultDir = homeDir
     try {
       const { tabId } = await window.clui.createTab()
       const tab: TabState = {
@@ -191,6 +259,8 @@ export const useSessionStore = create<State>((set, get) => ({
         tabs: [...s.tabs, tab],
         activeTabId: tab.id,
       }))
+      void get().refreshAgentMemory(homeDir)
+      void get().refreshAgentMemory(defaultDir)
       return tabId
     } catch {
       const tab = makeLocalTab()
@@ -199,6 +269,7 @@ export const useSessionStore = create<State>((set, get) => ({
         tabs: [...s.tabs, tab],
         activeTabId: tab.id,
       }))
+      void get().refreshAgentMemory(homeDir)
       return tab.id
     }
   },
@@ -216,6 +287,7 @@ export const useSessionStore = create<State>((set, get) => ({
           ? prev.tabs.map((t) => t.id === tabId ? { ...t, hasUnread: false } : t)
           : prev.tabs,
       }))
+      void get().refreshAgentMemory(getResolvedProjectPath(get().tabs.find((t) => t.id === tabId), get().staticInfo))
     } else {
       // Switching to a different tab: mark as read
       set((prev) => ({
@@ -225,6 +297,7 @@ export const useSessionStore = create<State>((set, get) => ({
           t.id === tabId ? { ...t, hasUnread: false } : t
         ),
       }))
+      void get().refreshAgentMemory(getResolvedProjectPath(get().tabs.find((t) => t.id === tabId), get().staticInfo))
     }
   },
 
@@ -345,13 +418,16 @@ export const useSessionStore = create<State>((set, get) => ({
       if (remaining.length === 0) {
         const newTab = makeLocalTab()
         set({ tabs: [newTab], activeTabId: newTab.id })
+        void get().refreshAgentMemory(getResolvedProjectPath(newTab, get().staticInfo))
         return
       }
       const closedIndex = s.tabs.findIndex((t) => t.id === tabId)
       const newActive = remaining[Math.min(closedIndex, remaining.length - 1)]
       set({ tabs: remaining, activeTabId: newActive.id })
+      void get().refreshAgentMemory(getResolvedProjectPath(newActive, get().staticInfo))
     } else {
       set({ tabs: remaining })
+      void get().refreshAgentMemory(getResolvedProjectPath(get().tabs.find((t) => t.id === s.activeTabId), get().staticInfo))
     }
   },
 
@@ -411,6 +487,8 @@ export const useSessionStore = create<State>((set, get) => ({
         isExpanded: true,
       }))
       return tab.id
+    } finally {
+      void get().refreshAgentMemory(defaultDir)
     }
   },
 
@@ -498,6 +576,7 @@ export const useSessionStore = create<State>((set, get) => ({
           : t
       ),
     }))
+    void get().refreshAgentMemory(dir)
   },
 
   // ─── Attachment management ───
@@ -531,6 +610,108 @@ export const useSessionStore = create<State>((set, get) => ({
         t.id === activeTabId ? { ...t, attachments: [] } : t
       ),
     }))
+  },
+
+  refreshAgentMemory: async (projectPath) => {
+    const { activeTabId, tabs, staticInfo } = get()
+    const activeTab = tabs.find((tab) => tab.id === activeTabId)
+    const resolvedProjectPath = projectPath || getResolvedProjectPath(activeTab, staticInfo)
+
+    try {
+      const snapshot = await window.clui.agentMemoryGet(resolvedProjectPath)
+      set((s) => ({
+        agentMemorySnapshot: snapshot,
+        tabs: applyAgentMemorySnapshotToTabs(s.tabs, snapshot, s.staticInfo),
+      }))
+      return snapshot
+    } catch {
+      return null
+    }
+  },
+
+  setAgentFocus: async (summary) => {
+    const { activeTabId, tabs, staticInfo } = get()
+    const tab = tabs.find((item) => item.id === activeTabId)
+    if (!tab) {
+      return null
+    }
+
+    const projectPath = getResolvedProjectPath(tab, staticInfo)
+    const result = await window.clui.agentMemoryFocus(
+      activeTabId,
+      projectPath,
+      getAgentLabel(activeTabId, tabs),
+      summary,
+    )
+
+    set((s) => ({
+      agentMemorySnapshot: result.snapshot,
+      tabs: applyAgentMemorySnapshotToTabs(s.tabs, result.snapshot, s.staticInfo),
+    }))
+
+    return result.snapshot.active.find((assignment) => assignment.tabId === activeTabId) || null
+  },
+
+  claimAgentWork: async (workKey, summary) => {
+    const { activeTabId, tabs, staticInfo } = get()
+    const tab = tabs.find((item) => item.id === activeTabId)
+    if (!tab) {
+      return null
+    }
+
+    const projectPath = getResolvedProjectPath(tab, staticInfo)
+    const result = await window.clui.agentMemoryClaim(
+      activeTabId,
+      projectPath,
+      getAgentLabel(activeTabId, tabs),
+      workKey,
+      summary,
+    )
+
+    set((s) => ({
+      agentMemorySnapshot: result.snapshot,
+      tabs: applyAgentMemorySnapshotToTabs(s.tabs, result.snapshot, s.staticInfo),
+    }))
+
+    return result
+  },
+
+  markAgentDone: async (note) => {
+    const { activeTabId } = get()
+    const result = await window.clui.agentMemoryDone(activeTabId, note)
+
+    set((s) => ({
+      agentMemorySnapshot: result.snapshot ?? s.agentMemorySnapshot,
+      tabs: result.snapshot
+        ? applyAgentMemorySnapshotToTabs(s.tabs, result.snapshot, s.staticInfo)
+        : s.tabs.map((tab) => tab.id === activeTabId ? { ...tab, agentAssignment: null } : tab),
+    }))
+
+    return result.ok
+  },
+
+  releaseAgentWork: async () => {
+    const { activeTabId } = get()
+    const result = await window.clui.agentMemoryRelease(activeTabId)
+
+    set((s) => {
+      let nextTabs = s.tabs.map((tab) => tab.id === activeTabId ? { ...tab, agentAssignment: null } : tab)
+      let nextSnapshot = s.agentMemorySnapshot
+
+      for (const snapshot of result.snapshots) {
+        nextTabs = applyAgentMemorySnapshotToTabs(nextTabs, snapshot, s.staticInfo)
+        if (s.agentMemorySnapshot?.projectPath === snapshot.projectPath) {
+          nextSnapshot = snapshot
+        }
+      }
+
+      return {
+        agentMemorySnapshot: nextSnapshot,
+        tabs: nextTabs,
+      }
+    })
+
+    return result.ok
   },
 
   stopRetrying: (tabId) => {
@@ -602,15 +783,16 @@ export const useSessionStore = create<State>((set, get) => ({
   sendMessage: (prompt, projectPath) => {
     const { activeTabId, tabs, staticInfo } = get()
     const tab = tabs.find((t) => t.id === activeTabId)
-    // Use explicitly chosen directory, otherwise fall back to user home
-    const resolvedPath = projectPath || (tab?.hasChosenDirectory ? tab.workingDirectory : (staticInfo?.homePath || tab?.workingDirectory || '~'))
     if (!tab) return
+    // Use explicitly chosen directory, otherwise fall back to user home
+    const resolvedPath = projectPath || getResolvedProjectPath(tab, staticInfo)
 
     // Guard: don't send while connecting (warmup in progress)
     if (tab.status === 'connecting') return
 
     const isBusy = tab.status === 'running'
     const requestId = crypto.randomUUID()
+    const shouldInferFocus = !tab.agentAssignment && prompt.trim().length > 0
 
     // Build full prompt with attachment context
     let fullPrompt = prompt
@@ -686,6 +868,10 @@ export const useSessionStore = create<State>((set, get) => ({
         toolCallCount: 0,
       })
     })
+
+    if (shouldInferFocus) {
+      void get().setAgentFocus(inferFocusSummary(prompt))
+    }
   },
 
   // ─── Event handlers ───

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -139,6 +139,29 @@ export interface RetryState {
   stopped?: boolean
 }
 
+export interface AgentAssignment {
+  tabId: string
+  agentLabel: string
+  projectPath: string
+  workKey?: string
+  summary: string
+  status: 'active' | 'done'
+  startedAt: string
+  updatedAt: string
+  doneAt?: string
+  note?: string
+}
+
+export interface AgentMemorySnapshot {
+  projectPath: string
+  active: AgentAssignment[]
+  recentDone: AgentAssignment[]
+}
+
+export type AgentMemoryClaimResult =
+  | { ok: true; snapshot: AgentMemorySnapshot; assignment: AgentAssignment }
+  | { ok: false; snapshot: AgentMemorySnapshot; conflict: AgentAssignment }
+
 export interface Attachment {
   id: string
   type: 'image' | 'file'
@@ -162,6 +185,7 @@ export interface TabState {
   /** Fallback card when tools were denied and no interactive permission is available */
   permissionDenied: { tools: Array<{ toolName: string; toolUseId: string }> } | null
   retryState: RetryState | null
+  agentAssignment: AgentAssignment | null
   lastRunOptions: RunOptions | null
   queuedRunOptions: RunOptions[]
   attachments: Attachment[]
@@ -334,6 +358,11 @@ export const IPC = {
   ANIMATE_HEIGHT: 'clui:animate-height',
   LIST_SESSIONS: 'clui:list-sessions',
   LOAD_SESSION: 'clui:load-session',
+  AGENT_MEMORY_GET: 'clui:agent-memory-get',
+  AGENT_MEMORY_FOCUS: 'clui:agent-memory-focus',
+  AGENT_MEMORY_CLAIM: 'clui:agent-memory-claim',
+  AGENT_MEMORY_DONE: 'clui:agent-memory-done',
+  AGENT_MEMORY_RELEASE: 'clui:agent-memory-release',
 
   // One-way events (main → renderer)
   TEXT_CHUNK: 'clui:text-chunk',

--- a/tests/unit/agent-memory.test.ts
+++ b/tests/unit/agent-memory.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { mkdirSync, rmSync } from 'fs'
+import { AgentMemory } from '../../src/main/agent-memory'
+
+describe('AgentMemory', () => {
+  const testDir = join(tmpdir(), `clui-agent-memory-${Date.now()}`)
+  const filePath = join(testDir, 'agent-memory.json')
+  let memory: AgentMemory
+
+  beforeEach(() => {
+    mkdirSync(testDir, { recursive: true })
+    memory = new AgentMemory(filePath, 3)
+  })
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true })
+  })
+
+  it('persists focus assignments per project', () => {
+    memory.setFocus({
+      tabId: 'tab-1',
+      projectPath: 'C:/repo',
+      agentLabel: 'Tab 1',
+      summary: 'Investigate CI failure',
+    })
+
+    const reloaded = new AgentMemory(filePath, 3)
+    const snapshot = reloaded.getSnapshot('C:/repo')
+
+    expect(snapshot.active).toHaveLength(1)
+    expect(snapshot.active[0].summary).toBe('Investigate CI failure')
+    expect(snapshot.active[0].agentLabel).toBe('Tab 1')
+  })
+
+  it('rejects a duplicate workKey claim in the same project', () => {
+    const first = memory.claim({
+      tabId: 'tab-1',
+      projectPath: 'C:/repo',
+      agentLabel: 'Tab 1',
+      workKey: 'github#123',
+      summary: 'Fix permissions flow',
+    })
+
+    const second = memory.claim({
+      tabId: 'tab-2',
+      projectPath: 'C:/repo',
+      agentLabel: 'Tab 2',
+      workKey: 'github#123',
+      summary: 'Implement same issue',
+    })
+
+    expect(first.ok).toBe(true)
+    expect(second.ok).toBe(false)
+    if (!second.ok) {
+      expect(second.conflict.tabId).toBe('tab-1')
+      expect(second.conflict.summary).toBe('Fix permissions flow')
+    }
+  })
+
+  it('allows the same workKey in different projects', () => {
+    memory.claim({
+      tabId: 'tab-1',
+      projectPath: 'C:/repo-a',
+      agentLabel: 'Tab 1',
+      workKey: 'github#123',
+      summary: 'Repo A issue',
+    })
+
+    const result = memory.claim({
+      tabId: 'tab-2',
+      projectPath: 'C:/repo-b',
+      agentLabel: 'Tab 2',
+      workKey: 'github#123',
+      summary: 'Repo B issue',
+    })
+
+    expect(result.ok).toBe(true)
+  })
+
+  it('moves the active assignment into recentDone when marked done', () => {
+    memory.claim({
+      tabId: 'tab-1',
+      projectPath: 'C:/repo',
+      agentLabel: 'Tab 1',
+      workKey: 'github#321',
+      summary: 'Ship retry banner',
+    })
+
+    const result = memory.markDone('tab-1', 'PR opened')
+
+    expect(result.ok).toBe(true)
+    expect(result.snapshot?.active).toHaveLength(0)
+    expect(result.snapshot?.recentDone).toHaveLength(1)
+    expect(result.snapshot?.recentDone[0].status).toBe('done')
+    expect(result.snapshot?.recentDone[0].note).toBe('PR opened')
+  })
+
+  it('releases active assignments for a tab without marking them done', () => {
+    memory.setFocus({
+      tabId: 'tab-1',
+      projectPath: 'C:/repo',
+      agentLabel: 'Tab 1',
+      summary: 'Explore notification UX',
+    })
+
+    const result = memory.release('tab-1')
+    const snapshot = memory.getSnapshot('C:/repo')
+
+    expect(result.ok).toBe(true)
+    expect(snapshot.active).toHaveLength(0)
+    expect(snapshot.recentDone).toHaveLength(0)
+  })
+
+  it('prunes stale active assignments using the live tab set', () => {
+    memory.setFocus({
+      tabId: 'tab-live',
+      projectPath: 'C:/repo',
+      agentLabel: 'Tab 1',
+      summary: 'Keep this one',
+    })
+    memory.setFocus({
+      tabId: 'tab-stale',
+      projectPath: 'C:/repo',
+      agentLabel: 'Tab 2',
+      summary: 'Remove this one',
+    })
+
+    memory.pruneStaleTabs(['tab-live'])
+
+    const snapshot = memory.getSnapshot('C:/repo')
+    expect(snapshot.active).toHaveLength(1)
+    expect(snapshot.active[0].tabId).toBe('tab-live')
+  })
+
+  it('builds a compact prompt context with current, active, and recent work', () => {
+    memory.claim({
+      tabId: 'tab-1',
+      projectPath: 'C:/repo',
+      agentLabel: 'Tab 1',
+      workKey: 'github#10',
+      summary: 'Implement memory persistence',
+    })
+    memory.claim({
+      tabId: 'tab-2',
+      projectPath: 'C:/repo',
+      agentLabel: 'Tab 2',
+      workKey: 'github#11',
+      summary: 'Fix retry UX',
+    })
+    memory.markDone('tab-2', 'Merged')
+
+    const prompt = memory.buildPromptContext('C:/repo', 'tab-1')
+
+    expect(prompt).toContain('Shared agent memory for this project:')
+    expect(prompt).toContain('Current assignment:')
+    expect(prompt).toContain('github#10 -> Tab 1: Implement memory persistence')
+    expect(prompt).toContain('Recent completed work:')
+    expect(prompt).toContain('github#11 -> Tab 2: Fix retry UX (Merged)')
+  })
+})


### PR DESCRIPTION
## Summary
- add persisted per-project agent memory with exclusive work claims and recent history
- inject shared agent memory context into Claude runs and expose memory operations over IPC/preload
- add renderer slash commands and a status bar summary for focus/claim/done/memory workflows

## Validation
- npm run test
- npm run build

Closes #50