### PR TITLE
FEAT-003: Add pinned session favorites

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -14,6 +14,7 @@ import { buildTerminalCommand } from './terminal-launch'
 import { buildScreenshotCommand, getScreenshotTempPath } from './screenshot'
 import { SettingsManager } from './settings-manager'
 import { AgentMemory } from './agent-memory'
+import { PinnedSessionStore } from './pinned-sessions'
 import { IPC } from '../shared/types'
 import type { RunOptions, NormalizedEvent, EnrichedError } from '../shared/types'
 
@@ -33,6 +34,7 @@ let toggleSequence = 0
 const INTERACTIVE_PTY = process.env.CLUI_INTERACTIVE_PERMISSIONS_PTY === '1'
 
 const settingsManager = new SettingsManager()
+const pinnedSessions = new PinnedSessionStore()
 let agentMemory: AgentMemory | null = null
 
 const controlPlane = new ControlPlane(INTERACTIVE_PTY)
@@ -409,23 +411,42 @@ ipcMain.handle(IPC.LIST_SESSIONS, async (_e, projectPath?: string) => {
       })
 
       if (meta.validated) {
+        const pinnedAt = pinnedSessions.getPinnedAt(fileSessionId, cwd)
         sessions.push({
           sessionId: fileSessionId,
           slug: meta.slug,
           firstMessage: meta.firstMessage,
           lastTimestamp: meta.lastTimestamp || stat.mtime.toISOString(),
           size: stat.size,
+          pinned: pinnedAt !== null,
         })
       }
     }
 
-    // Sort by last timestamp, most recent first
-    sessions.sort((a, b) => new Date(b.lastTimestamp).getTime() - new Date(a.lastTimestamp).getTime())
+    sessions.sort((a, b) => {
+      if (a.pinned !== b.pinned) return a.pinned ? -1 : 1
+      const aPinnedAt = pinnedSessions.getPinnedAt(a.sessionId, cwd) || 0
+      const bPinnedAt = pinnedSessions.getPinnedAt(b.sessionId, cwd) || 0
+      if (a.pinned && b.pinned && aPinnedAt !== bPinnedAt) return bPinnedAt - aPinnedAt
+      return new Date(b.lastTimestamp).getTime() - new Date(a.lastTimestamp).getTime()
+    })
     return sessions.slice(0, 20) // Return top 20
   } catch (err) {
     log(`LIST_SESSIONS error: ${err}`)
     return []
   }
+})
+
+ipcMain.handle(IPC.PIN_SESSION, (_event, { sessionId, projectPath }: { sessionId: string; projectPath: string }) => {
+  log(`IPC PIN_SESSION: ${sessionId}`)
+  pinnedSessions.pin(sessionId, projectPath)
+  return true
+})
+
+ipcMain.handle(IPC.UNPIN_SESSION, (_event, sessionId: string) => {
+  log(`IPC UNPIN_SESSION: ${sessionId}`)
+  pinnedSessions.unpin(sessionId)
+  return true
 })
 
 // Load conversation history from a session's JSONL file

--- a/src/main/pinned-sessions.ts
+++ b/src/main/pinned-sessions.ts
@@ -1,0 +1,88 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
+import { dirname, join } from 'path'
+import { homedir } from 'os'
+
+interface PinnedSessionEntry {
+  pinnedAt: number
+  projectPath: string
+}
+
+interface PinnedSessionFile {
+  pins: Record<string, PinnedSessionEntry>
+}
+
+const DEFAULT_FILE_PATH = join(homedir(), '.clui', 'pinned-sessions.json')
+
+export class PinnedSessionStore {
+  private filePath: string
+
+  constructor(filePath = DEFAULT_FILE_PATH) {
+    this.filePath = filePath
+  }
+
+  isPinned(sessionId: string, projectPath: string): boolean {
+    const entry = this.readState().pins[sessionId]
+    return !!entry && entry.projectPath === projectPath
+  }
+
+  getPinnedAt(sessionId: string, projectPath: string): number | null {
+    const entry = this.readState().pins[sessionId]
+    if (!entry || entry.projectPath !== projectPath) {
+      return null
+    }
+    return entry.pinnedAt
+  }
+
+  pin(sessionId: string, projectPath: string): void {
+    const state = this.readState()
+    state.pins[sessionId] = {
+      pinnedAt: Date.now(),
+      projectPath,
+    }
+    this.writeState(state)
+  }
+
+  unpin(sessionId: string): void {
+    const state = this.readState()
+    if (!state.pins[sessionId]) {
+      return
+    }
+    delete state.pins[sessionId]
+    this.writeState(state)
+  }
+
+  private readState(): PinnedSessionFile {
+    try {
+      if (!existsSync(this.filePath)) {
+        return { pins: {} }
+      }
+
+      const raw = JSON.parse(readFileSync(this.filePath, 'utf-8'))
+      const pins: Record<string, PinnedSessionEntry> = {}
+
+      if (raw?.pins && typeof raw.pins === 'object') {
+        for (const [sessionId, entry] of Object.entries(raw.pins as Record<string, any>)) {
+          if (typeof entry?.pinnedAt !== 'number' || typeof entry?.projectPath !== 'string') {
+            continue
+          }
+          pins[sessionId] = {
+            pinnedAt: entry.pinnedAt,
+            projectPath: entry.projectPath,
+          }
+        }
+      }
+
+      return { pins }
+    } catch {
+      return { pins: {} }
+    }
+  }
+
+  private writeState(state: PinnedSessionFile): void {
+    const dir = dirname(this.filePath)
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true })
+    }
+    writeFileSync(this.filePath, JSON.stringify(state, null, 2), 'utf-8')
+  }
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -37,6 +37,8 @@ export interface CluiAPI {
   resetTabSession(tabId: string): void
   listSessions(projectPath?: string): Promise<SessionMeta[]>
   loadSession(sessionId: string, projectPath?: string): Promise<SessionLoadMessage[]>
+  pinSession(sessionId: string, projectPath: string): Promise<boolean>
+  unpinSession(sessionId: string): Promise<boolean>
   agentMemoryGet(projectPath: string): Promise<AgentMemorySnapshot>
   agentMemoryFocus(tabId: string, projectPath: string, agentLabel: string, summary: string): Promise<{ snapshot: AgentMemorySnapshot }>
   agentMemoryClaim(tabId: string, projectPath: string, agentLabel: string, workKey: string, summary: string): Promise<AgentMemoryClaimResult>
@@ -98,6 +100,8 @@ const api: CluiAPI = {
   resetTabSession: (tabId) => ipcRenderer.send(IPC.RESET_TAB_SESSION, tabId),
   listSessions: (projectPath?: string) => ipcRenderer.invoke(IPC.LIST_SESSIONS, projectPath),
   loadSession: (sessionId: string, projectPath?: string) => ipcRenderer.invoke(IPC.LOAD_SESSION, { sessionId, projectPath }),
+  pinSession: (sessionId, projectPath) => ipcRenderer.invoke(IPC.PIN_SESSION, { sessionId, projectPath }),
+  unpinSession: (sessionId) => ipcRenderer.invoke(IPC.UNPIN_SESSION, sessionId),
   agentMemoryGet: (projectPath) => ipcRenderer.invoke(IPC.AGENT_MEMORY_GET, projectPath),
   agentMemoryFocus: (tabId, projectPath, agentLabel, summary) =>
     ipcRenderer.invoke(IPC.AGENT_MEMORY_FOCUS, { tabId, projectPath, agentLabel, summary }),

--- a/src/renderer/components/HistoryPicker.tsx
+++ b/src/renderer/components/HistoryPicker.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react'
 import { createPortal } from 'react-dom'
 import { motion } from 'framer-motion'
-import { Clock, ChatCircle } from '@phosphor-icons/react'
+import { Clock, ChatCircle, PushPin } from '@phosphor-icons/react'
 import { useSessionStore } from '../stores/sessionStore'
 import { usePopoverLayer } from './PopoverLayer'
 import { useColors } from '../theme'
@@ -103,6 +103,21 @@ export function HistoryPicker() {
     void resumeSession(session.sessionId, title, effectiveProjectPath)
   }
 
+  const handleTogglePin = async (session: SessionMeta, event: React.MouseEvent) => {
+    event.stopPropagation()
+    try {
+      if (session.pinned) {
+        await window.clui.unpinSession(session.sessionId)
+      } else {
+        await window.clui.pinSession(session.sessionId, effectiveProjectPath)
+      }
+      await loadSessions()
+    } catch {}
+  }
+
+  const pinnedSessions = sessions.filter((session) => session.pinned)
+  const recentSessions = sessions.filter((session) => !session.pinned)
+
   return (
     <>
       <button
@@ -143,7 +158,7 @@ export function HistoryPicker() {
           }}
         >
           <div className="px-3 py-2 text-[11px] font-medium flex-shrink-0" style={{ color: colors.textTertiary, borderBottom: `1px solid ${colors.popoverBorder}` }}>
-            Recent Sessions
+            Session History
           </div>
 
           <div className="overflow-y-auto py-1" style={{ maxHeight: pos.maxHeight != null ? undefined : 180 }}>
@@ -159,25 +174,91 @@ export function HistoryPicker() {
               </div>
             )}
 
-            {!loading && sessions.map((session) => (
-              <button
-                key={session.sessionId}
-                onClick={() => handleSelect(session)}
-                className="w-full flex items-start gap-2.5 px-3 py-2 text-left transition-colors"
-              >
-                <ChatCircle size={13} className="flex-shrink-0 mt-0.5" style={{ color: colors.textTertiary }} />
-                <div className="min-w-0 flex-1">
-                  <div className="text-[11px] truncate" style={{ color: colors.textPrimary }}>
-                    {session.firstMessage || session.slug || session.sessionId.substring(0, 8)}
-                  </div>
-                  <div className="flex items-center gap-2 text-[10px] mt-0.5" style={{ color: colors.textTertiary }}>
-                    <span>{formatTimeAgo(session.lastTimestamp)}</span>
-                    <span>{formatSize(session.size)}</span>
-                    {session.slug && <span className="truncate">{session.slug}</span>}
-                  </div>
+            {!loading && pinnedSessions.length > 0 && (
+              <>
+                <div
+                  className="px-3 pt-2 pb-1 text-[10px] uppercase tracking-wider"
+                  style={{ color: colors.textTertiary }}
+                >
+                  Pinned ({pinnedSessions.length})
                 </div>
-              </button>
-            ))}
+                {pinnedSessions.map((session) => (
+                  <div
+                    key={session.sessionId}
+                    className="flex items-start gap-2.5 px-3 py-2"
+                    style={{ borderLeft: `2px solid ${colors.accent}` }}
+                  >
+                    <button
+                      onClick={() => handleSelect(session)}
+                      className="min-w-0 flex-1 flex items-start gap-2.5 text-left transition-colors"
+                    >
+                      <ChatCircle size={13} className="flex-shrink-0 mt-0.5" style={{ color: colors.accent }} />
+                      <div className="min-w-0 flex-1">
+                        <div className="text-[11px] truncate" style={{ color: colors.textPrimary }}>
+                          {session.firstMessage || session.slug || session.sessionId.substring(0, 8)}
+                        </div>
+                        <div className="flex items-center gap-2 text-[10px] mt-0.5" style={{ color: colors.textTertiary }}>
+                          <span>{formatTimeAgo(session.lastTimestamp)}</span>
+                          <span>{formatSize(session.size)}</span>
+                          {session.slug && <span className="truncate">{session.slug}</span>}
+                        </div>
+                      </div>
+                    </button>
+                    <button
+                      onClick={(event) => void handleTogglePin(session, event)}
+                      className="flex-shrink-0 mt-0.5"
+                      style={{ color: colors.accent }}
+                      title="Unpin session"
+                    >
+                      <PushPin size={13} weight="fill" />
+                    </button>
+                  </div>
+                ))}
+                <div className="mx-3 my-1" style={{ height: 1, background: colors.popoverBorder }} />
+              </>
+            )}
+
+            {!loading && recentSessions.length > 0 && (
+              <>
+                <div
+                  className="px-3 pt-2 pb-1 text-[10px] uppercase tracking-wider"
+                  style={{ color: colors.textTertiary }}
+                >
+                  Recent
+                </div>
+                {recentSessions.map((session) => (
+                  <div
+                    key={session.sessionId}
+                    className="flex items-start gap-2.5 px-3 py-2"
+                  >
+                    <button
+                      onClick={() => handleSelect(session)}
+                      className="min-w-0 flex-1 flex items-start gap-2.5 text-left transition-colors"
+                    >
+                      <ChatCircle size={13} className="flex-shrink-0 mt-0.5" style={{ color: colors.textTertiary }} />
+                      <div className="min-w-0 flex-1">
+                        <div className="text-[11px] truncate" style={{ color: colors.textPrimary }}>
+                          {session.firstMessage || session.slug || session.sessionId.substring(0, 8)}
+                        </div>
+                        <div className="flex items-center gap-2 text-[10px] mt-0.5" style={{ color: colors.textTertiary }}>
+                          <span>{formatTimeAgo(session.lastTimestamp)}</span>
+                          <span>{formatSize(session.size)}</span>
+                          {session.slug && <span className="truncate">{session.slug}</span>}
+                        </div>
+                      </div>
+                    </button>
+                    <button
+                      onClick={(event) => void handleTogglePin(session, event)}
+                      className="flex-shrink-0 mt-0.5"
+                      style={{ color: colors.textTertiary }}
+                      title="Pin session"
+                    >
+                      <PushPin size={13} />
+                    </button>
+                  </div>
+                ))}
+              </>
+            )}
           </div>
         </motion.div>,
         popoverLayer,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -303,6 +303,7 @@ export interface SessionMeta {
   firstMessage: string | null
   lastTimestamp: string
   size: number
+  pinned: boolean
 }
 
 export interface SessionLoadMessage {
@@ -363,6 +364,8 @@ export const IPC = {
   AGENT_MEMORY_CLAIM: 'clui:agent-memory-claim',
   AGENT_MEMORY_DONE: 'clui:agent-memory-done',
   AGENT_MEMORY_RELEASE: 'clui:agent-memory-release',
+  PIN_SESSION: 'clui:pin-session',
+  UNPIN_SESSION: 'clui:unpin-session',
 
   // One-way events (main → renderer)
   TEXT_CHUNK: 'clui:text-chunk',

--- a/tests/unit/pinned-sessions.test.ts
+++ b/tests/unit/pinned-sessions.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdirSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { PinnedSessionStore } from '../../src/main/pinned-sessions'
+
+describe('PinnedSessionStore', () => {
+  const testDir = join(tmpdir(), `clui-pinned-sessions-${Date.now()}`)
+  const filePath = join(testDir, 'pinned-sessions.json')
+  let store: PinnedSessionStore
+
+  beforeEach(() => {
+    mkdirSync(testDir, { recursive: true })
+    store = new PinnedSessionStore(filePath)
+  })
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true })
+  })
+
+  it('pins a session for a project and persists it', () => {
+    store.pin('session-1', 'C:/repo')
+
+    const reloaded = new PinnedSessionStore(filePath)
+    expect(reloaded.isPinned('session-1', 'C:/repo')).toBe(true)
+    expect(reloaded.getPinnedAt('session-1', 'C:/repo')).toBeTypeOf('number')
+  })
+
+  it('does not report a session as pinned for a different project', () => {
+    store.pin('session-1', 'C:/repo-a')
+
+    expect(store.isPinned('session-1', 'C:/repo-b')).toBe(false)
+    expect(store.getPinnedAt('session-1', 'C:/repo-b')).toBeNull()
+  })
+
+  it('unpins a session cleanly', () => {
+    store.pin('session-1', 'C:/repo')
+    store.unpin('session-1')
+
+    expect(store.isPinned('session-1', 'C:/repo')).toBe(false)
+    expect(store.getPinnedAt('session-1', 'C:/repo')).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- persist pinned sessions per project in a local store and expose pin/unpin over IPC
- enrich session history results with pinned metadata and pin-aware sorting
- split HistoryPicker into Pinned and Recent sections with inline pin toggles

## Validation
- npm run test
- npm run build

Closes #37