### PR TITLE
FEAT-001: Add snippets and prompt templates

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -6,11 +6,13 @@ import { ConversationView } from './components/ConversationView'
 import { InputBar } from './components/InputBar'
 import { StatusBar } from './components/StatusBar'
 import { MarketplacePanel } from './components/MarketplacePanel'
+import { SnippetManager } from './components/SnippetManager'
 import { PermissionWizard } from './components/PermissionWizard'
 import { PopoverLayerProvider } from './components/PopoverLayer'
 import { useClaudeEvents } from './hooks/useClaudeEvents'
 import { useHealthReconciliation } from './hooks/useHealthReconciliation'
 import { useSessionStore } from './stores/sessionStore'
+import { useSnippetStore } from './stores/snippetStore'
 import { useColors, useThemeStore, spacing } from './theme'
 
 const TRANSITION = { duration: 0.26, ease: [0.4, 0, 0.1, 1] as const }
@@ -102,6 +104,7 @@ export default function App() {
 
   const isExpanded = useSessionStore((s) => s.isExpanded)
   const marketplaceOpen = useSessionStore((s) => s.marketplaceOpen)
+  const snippetManagerOpen = useSnippetStore((s) => s.managerOpen)
   const isRunning = activeTabStatus === 'running' || activeTabStatus === 'connecting'
 
   // Layout dimensions — expandedUI widens and heightens the panel
@@ -168,6 +171,41 @@ export default function App() {
                     }}
                   >
                     <MarketplacePanel />
+                  </div>
+                </motion.div>
+              </div>
+            )}
+          </AnimatePresence>
+
+          <AnimatePresence initial={false}>
+            {snippetManagerOpen && (
+              <div
+                data-clui-ui
+                style={{
+                  width: 720,
+                  maxWidth: 720,
+                  marginLeft: '50%',
+                  transform: 'translateX(-50%)',
+                  marginBottom: 14,
+                  position: 'relative',
+                  zIndex: 29,
+                }}
+              >
+                <motion.div
+                  initial={{ opacity: 0, y: 14, scale: 0.98 }}
+                  animate={{ opacity: 1, y: 0, scale: 1 }}
+                  exit={{ opacity: 0, y: 10, scale: 0.985 }}
+                  transition={TRANSITION}
+                >
+                  <div
+                    data-clui-ui
+                    className="glass-surface overflow-hidden no-drag"
+                    style={{
+                      borderRadius: 24,
+                      maxHeight: 470,
+                    }}
+                  >
+                    <SnippetManager />
                   </div>
                 </motion.div>
               </div>

--- a/src/renderer/components/InputBar.tsx
+++ b/src/renderer/components/InputBar.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useRef, useCallback, useEffect, useLayoutEffect } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
-import { Microphone, ArrowUp, SpinnerGap, X, Check } from '@phosphor-icons/react'
+import { Microphone, ArrowUp, SpinnerGap, X, Check, Sparkle, Lightning } from '@phosphor-icons/react'
 import { useSessionStore, AVAILABLE_MODELS } from '../stores/sessionStore'
+import { useSnippetStore } from '../stores/snippetStore'
 import { AttachmentChips } from './AttachmentChips'
 import { SlashCommandMenu, getFilteredCommandsWithExtras, type SlashCommand } from './SlashCommandMenu'
 import { useColors } from '../theme'
@@ -85,6 +86,7 @@ export function InputBar() {
   const preferredModel = useSessionStore((s) => s.preferredModel)
   const activeTabId = useSessionStore((s) => s.activeTabId)
   const tab = useSessionStore((s) => s.tabs.find((t) => t.id === s.activeTabId))
+  const snippets = useSnippetStore((s) => s.snippets)
   const colors = useColors()
   const isBusy = tab?.status === 'running' || tab?.status === 'connecting'
   const isConnecting = tab?.status === 'connecting'
@@ -95,7 +97,14 @@ export function InputBar() {
   const skillCommands: SlashCommand[] = (tab?.sessionSkills || []).map((skill) => ({
     command: `/${skill}`,
     description: `Run skill: ${skill}`,
-    icon: <span className="text-[11px]">✦</span>,
+    icon: <Sparkle size={12} />,
+  }))
+  const snippetCommands: SlashCommand[] = snippets.map((snippet) => ({
+    command: snippet.command,
+    description: `Snippet: ${snippet.name}`,
+    icon: <Lightning size={12} />,
+    badge: 'Snippet',
+    insertText: snippet.content,
   }))
 
   useEffect(() => {
@@ -279,6 +288,12 @@ export function InputBar() {
 
   const handleSlashSelect = useCallback((cmd: SlashCommand) => {
     const isSkillCommand = !!tab?.sessionSkills?.includes(cmd.command.replace(/^\//, ''))
+    if (cmd.insertText) {
+      setInput(cmd.insertText)
+      setSlashFilter(null)
+      requestAnimationFrame(() => textareaRef.current?.focus())
+      return
+    }
     if (isSkillCommand || cmd.insertOnly) {
       setInput(`${cmd.command} `)
       setSlashFilter(null)
@@ -293,7 +308,7 @@ export function InputBar() {
   // ─── Send ───
   const handleSend = useCallback(async () => {
     if (showSlashMenu) {
-      const filtered = getFilteredCommandsWithExtras(slashFilter!, skillCommands)
+      const filtered = getFilteredCommandsWithExtras(slashFilter!, [...snippetCommands, ...skillCommands])
       if (filtered.length > 0) {
         handleSlashSelect(filtered[slashIndex])
         return
@@ -397,14 +412,16 @@ export function InputBar() {
     agentMemorySnapshot,
     activeTabId,
     addSystemMessage,
+    snippetCommands,
+    skillCommands,
   ])
 
   // ─── Keyboard ───
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (showSlashMenu) {
-      const filtered = getFilteredCommandsWithExtras(slashFilter!, skillCommands)
-      if (e.key === 'ArrowDown') { e.preventDefault(); setSlashIndex((i) => (i + 1) % filtered.length); return }
-      if (e.key === 'ArrowUp') { e.preventDefault(); setSlashIndex((i) => (i - 1 + filtered.length) % filtered.length); return }
+      const filtered = getFilteredCommandsWithExtras(slashFilter!, [...snippetCommands, ...skillCommands])
+      if (e.key === 'ArrowDown' && filtered.length > 0) { e.preventDefault(); setSlashIndex((i) => (i + 1) % filtered.length); return }
+      if (e.key === 'ArrowUp' && filtered.length > 0) { e.preventDefault(); setSlashIndex((i) => (i - 1 + filtered.length) % filtered.length); return }
       if (e.key === 'Tab') { e.preventDefault(); if (filtered.length > 0) handleSlashSelect(filtered[slashIndex]); return }
       if (e.key === 'Escape') { e.preventDefault(); setSlashFilter(null); return }
     }
@@ -502,7 +519,7 @@ export function InputBar() {
             selectedIndex={slashIndex}
             onSelect={handleSlashSelect}
             anchorRect={wrapperRef.current?.getBoundingClientRect() ?? null}
-            extraCommands={skillCommands}
+            extraCommands={[...snippetCommands, ...skillCommands]}
           />
         )}
       </AnimatePresence>

--- a/src/renderer/components/SettingsPopover.tsx
+++ b/src/renderer/components/SettingsPopover.tsx
@@ -1,9 +1,10 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react'
 import { createPortal } from 'react-dom'
 import { motion } from 'framer-motion'
-import { DotsThree, Bell, ArrowsOutSimple, Moon, ShieldCheck } from '@phosphor-icons/react'
+import { DotsThree, Bell, ArrowsOutSimple, Moon, ShieldCheck, NotePencil } from '@phosphor-icons/react'
 import { useThemeStore } from '../theme'
 import { useSessionStore } from '../stores/sessionStore'
+import { useSnippetStore } from '../stores/snippetStore'
 import { usePopoverLayer } from './PopoverLayer'
 import { useColors } from '../theme'
 import { PermissionEditor } from './PermissionEditor'
@@ -53,6 +54,7 @@ export function SettingsPopover() {
   const setThemeMode = useThemeStore((s) => s.setThemeMode)
   const expandedUI = useThemeStore((s) => s.expandedUI)
   const setExpandedUI = useThemeStore((s) => s.setExpandedUI)
+  const openSnippetManager = useSnippetStore((s) => s.openManager)
   const isExpanded = useSessionStore((s) => s.isExpanded)
   const popoverLayer = usePopoverLayer()
   const colors = useColors()
@@ -261,6 +263,24 @@ export function SettingsPopover() {
                 <ShieldCheck size={14} style={{ color: colors.textTertiary }} />
                 <div className="text-[12px] font-medium" style={{ color: colors.textPrimary }}>
                   Permissions
+                </div>
+              </button>
+            </div>
+
+            <div style={{ height: 1, background: colors.popoverBorder }} />
+
+            <div>
+              <button
+                onClick={() => {
+                  openSnippetManager()
+                  setOpen(false)
+                }}
+                className="flex items-center gap-2 w-full text-left cursor-pointer rounded-md px-0 py-0 transition-colors"
+                style={{ background: 'transparent' }}
+              >
+                <NotePencil size={14} style={{ color: colors.textTertiary }} />
+                <div className="text-[12px] font-medium" style={{ color: colors.textPrimary }}>
+                  Snippets
                 </div>
               </button>
             </div>

--- a/src/renderer/components/SlashCommandMenu.tsx
+++ b/src/renderer/components/SlashCommandMenu.tsx
@@ -11,7 +11,9 @@ export interface SlashCommand {
   command: string
   description: string
   icon: React.ReactNode
+  badge?: string
   insertOnly?: boolean
+  insertText?: string
 }
 
 export const SLASH_COMMANDS: SlashCommand[] = [
@@ -120,18 +122,31 @@ export function SlashCommandMenu({ filter, selectedIndex, onSelect, anchorRect, 
                 {cmd.icon}
               </span>
               <div className="min-w-0 flex-1">
-                <span
-                  className="text-[12px] font-mono font-medium"
-                  style={{ color: isSelected ? colors.accent : colors.textPrimary }}
-                >
-                  {cmd.command}
-                </span>
-                <span
-                  className="text-[11px] ml-2"
+                <div className="flex items-center gap-2 min-w-0">
+                  <span
+                    className="text-[12px] font-mono font-medium"
+                    style={{ color: isSelected ? colors.accent : colors.textPrimary }}
+                  >
+                    {cmd.command}
+                  </span>
+                  {cmd.badge && (
+                    <span
+                      className="text-[9px] uppercase tracking-[0.14em] px-1.5 py-0.5 rounded-full"
+                      style={{
+                        color: isSelected ? colors.accent : colors.textTertiary,
+                        background: isSelected ? colors.accentSoft : colors.surfaceHover,
+                      }}
+                    >
+                      {cmd.badge}
+                    </span>
+                  )}
+                </div>
+                <div
+                  className="text-[11px]"
                   style={{ color: colors.textTertiary }}
                 >
                   {cmd.description}
-                </span>
+                </div>
               </div>
             </button>
           )

--- a/src/renderer/components/SnippetManager.tsx
+++ b/src/renderer/components/SnippetManager.tsx
@@ -1,0 +1,270 @@
+import React, { useMemo, useState } from 'react'
+import { Lightning, NotePencil, Plus, Trash, X } from '@phosphor-icons/react'
+import { useColors } from '../theme'
+import { useSnippetStore } from '../stores/snippetStore'
+
+interface DraftState {
+  name: string
+  command: string
+  content: string
+}
+
+const EMPTY_DRAFT: DraftState = {
+  name: '',
+  command: '',
+  content: '',
+}
+
+export function SnippetManager() {
+  const colors = useColors()
+  const snippets = useSnippetStore((s) => s.snippets)
+  const closeManager = useSnippetStore((s) => s.closeManager)
+  const addSnippet = useSnippetStore((s) => s.addSnippet)
+  const updateSnippet = useSnippetStore((s) => s.updateSnippet)
+  const deleteSnippet = useSnippetStore((s) => s.deleteSnippet)
+
+  const [search, setSearch] = useState('')
+  const [draft, setDraft] = useState<DraftState>(EMPTY_DRAFT)
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [editingDraft, setEditingDraft] = useState<DraftState>(EMPTY_DRAFT)
+  const [error, setError] = useState<string | null>(null)
+
+  const filtered = useMemo(() => {
+    const query = search.trim().toLowerCase()
+    if (!query) return snippets
+    return snippets.filter((snippet) =>
+      snippet.name.toLowerCase().includes(query)
+      || snippet.command.toLowerCase().includes(query)
+      || snippet.content.toLowerCase().includes(query)
+    )
+  }, [search, snippets])
+
+  const handleCreate = () => {
+    const created = addSnippet(draft.name, draft.command, draft.content)
+    if (!created) {
+      setError('Invalid snippet. Command must be unique, start with /, and content cannot be empty.')
+      return
+    }
+    setDraft(EMPTY_DRAFT)
+    setError(null)
+  }
+
+  const startEditing = (id: string, name: string, command: string, content: string) => {
+    setEditingId(id)
+    setEditingDraft({ name, command, content })
+    setError(null)
+  }
+
+  const handleSaveEdit = () => {
+    if (!editingId) return
+    const ok = updateSnippet(editingId, editingDraft)
+    if (!ok) {
+      setError('Invalid snippet update. Command must stay unique and content cannot be empty.')
+      return
+    }
+    setEditingId(null)
+    setEditingDraft(EMPTY_DRAFT)
+    setError(null)
+  }
+
+  return (
+    <div
+      data-clui-ui
+      style={{
+        height: 470,
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
+      <div style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        padding: '16px 18px 10px',
+        borderBottom: `1px solid ${colors.containerBorder}`,
+      }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <Lightning size={20} style={{ color: colors.accent }} />
+          <div>
+            <div style={{ fontSize: 13, fontWeight: 700, color: colors.textPrimary }}>
+              Manage Snippets
+            </div>
+            <div style={{ fontSize: 11, color: colors.textTertiary, marginTop: 2 }}>
+              Reusable prompt templates for slash commands
+            </div>
+          </div>
+        </div>
+        <button
+          onClick={closeManager}
+          aria-label="Close snippets"
+          className="w-7 h-7 rounded-full flex items-center justify-center"
+          style={{ color: colors.textTertiary }}
+          title="Close snippets"
+        >
+          <X size={15} />
+        </button>
+      </div>
+
+      <div style={{ padding: 16, borderBottom: `1px solid ${colors.containerBorder}` }}>
+        <input
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          placeholder="Search snippets..."
+          className="w-full rounded-xl px-3 py-2 text-[12px]"
+          style={{
+            background: colors.surfacePrimary,
+            color: colors.textPrimary,
+            border: `1px solid ${colors.containerBorder}`,
+          }}
+        />
+      </div>
+
+      <div style={{ padding: 16, borderBottom: `1px solid ${colors.containerBorder}` }}>
+        <div className="text-[11px] font-medium mb-2" style={{ color: colors.textPrimary }}>
+          Add New Snippet
+        </div>
+        <div className="grid gap-2">
+          <input
+            value={draft.name}
+            onChange={(event) => setDraft((current) => ({ ...current, name: event.target.value }))}
+            placeholder="Name"
+            className="rounded-xl px-3 py-2 text-[12px]"
+            style={{ background: colors.surfacePrimary, color: colors.textPrimary, border: `1px solid ${colors.containerBorder}` }}
+          />
+          <input
+            value={draft.command}
+            onChange={(event) => setDraft((current) => ({ ...current, command: event.target.value }))}
+            placeholder="/review"
+            className="rounded-xl px-3 py-2 text-[12px] font-mono"
+            style={{ background: colors.surfacePrimary, color: colors.textPrimary, border: `1px solid ${colors.containerBorder}` }}
+          />
+          <textarea
+            value={draft.content}
+            onChange={(event) => setDraft((current) => ({ ...current, content: event.target.value }))}
+            placeholder="Snippet content..."
+            className="rounded-xl px-3 py-2 text-[12px] resize-none"
+            rows={3}
+            style={{ background: colors.surfacePrimary, color: colors.textPrimary, border: `1px solid ${colors.containerBorder}` }}
+          />
+          <button
+            onClick={handleCreate}
+            className="rounded-xl px-3 py-2 text-[12px] font-medium flex items-center gap-2 justify-center"
+            style={{ background: colors.accent, color: colors.textOnAccent }}
+          >
+            <Plus size={14} />
+            Add Snippet
+          </button>
+          {error && (
+            <div className="text-[11px]" style={{ color: colors.statusError }}>
+              {error}
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div style={{ flex: 1, overflowY: 'auto', padding: 16 }}>
+        {filtered.length === 0 ? (
+          <div
+            className="rounded-2xl px-4 py-6 text-center"
+            style={{ background: colors.surfacePrimary, color: colors.textTertiary, border: `1px solid ${colors.containerBorder}` }}
+          >
+            No snippets yet. Create your first template.
+          </div>
+        ) : (
+          <div className="grid gap-3" role="listbox" aria-label="Saved snippets">
+            {filtered.map((snippet) => {
+              const isEditing = editingId === snippet.id
+              return (
+                <div
+                  key={snippet.id}
+                  className="rounded-2xl p-3"
+                  style={{ background: colors.surfacePrimary, border: `1px solid ${colors.containerBorder}` }}
+                >
+                  {isEditing ? (
+                    <div className="grid gap-2">
+                      <input
+                        value={editingDraft.name}
+                        onChange={(event) => setEditingDraft((current) => ({ ...current, name: event.target.value }))}
+                        className="rounded-xl px-3 py-2 text-[12px]"
+                        style={{ background: colors.inputPillBg, color: colors.textPrimary, border: `1px solid ${colors.containerBorder}` }}
+                      />
+                      <input
+                        value={editingDraft.command}
+                        onChange={(event) => setEditingDraft((current) => ({ ...current, command: event.target.value }))}
+                        className="rounded-xl px-3 py-2 text-[12px] font-mono"
+                        style={{ background: colors.inputPillBg, color: colors.textPrimary, border: `1px solid ${colors.containerBorder}` }}
+                      />
+                      <textarea
+                        value={editingDraft.content}
+                        onChange={(event) => setEditingDraft((current) => ({ ...current, content: event.target.value }))}
+                        className="rounded-xl px-3 py-2 text-[12px] resize-none"
+                        rows={4}
+                        style={{ background: colors.inputPillBg, color: colors.textPrimary, border: `1px solid ${colors.containerBorder}` }}
+                      />
+                      <div className="flex items-center gap-2 justify-end">
+                        <button
+                          onClick={() => {
+                            setEditingId(null)
+                            setEditingDraft(EMPTY_DRAFT)
+                            setError(null)
+                          }}
+                          className="rounded-xl px-3 py-2 text-[12px]"
+                          style={{ color: colors.textSecondary, background: colors.surfaceSecondary }}
+                        >
+                          Cancel
+                        </button>
+                        <button
+                          onClick={handleSaveEdit}
+                          className="rounded-xl px-3 py-2 text-[12px] font-medium"
+                          style={{ background: colors.accent, color: colors.textOnAccent }}
+                        >
+                          Save
+                        </button>
+                      </div>
+                    </div>
+                  ) : (
+                    <>
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="min-w-0">
+                          <div className="text-[12px] font-medium" style={{ color: colors.textPrimary }}>
+                            {snippet.name}
+                          </div>
+                          <div className="text-[11px] font-mono mt-1" style={{ color: colors.accent }}>
+                            {snippet.command}
+                          </div>
+                        </div>
+                        <div className="flex items-center gap-1">
+                          <button
+                            onClick={() => startEditing(snippet.id, snippet.name, snippet.command, snippet.content)}
+                            aria-label={`Edit snippet ${snippet.name}`}
+                            className="w-8 h-8 rounded-full flex items-center justify-center"
+                            style={{ color: colors.textTertiary, background: colors.surfaceSecondary }}
+                            title="Edit snippet"
+                          >
+                            <NotePencil size={14} />
+                          </button>
+                          <button
+                            onClick={() => deleteSnippet(snippet.id)}
+                            aria-label={`Delete snippet ${snippet.name}`}
+                            className="w-8 h-8 rounded-full flex items-center justify-center"
+                            style={{ color: colors.statusError, background: colors.surfaceSecondary }}
+                            title="Delete snippet"
+                          >
+                            <Trash size={14} />
+                          </button>
+                        </div>
+                      </div>
+                      <div className="text-[11px] mt-2 whitespace-pre-wrap" style={{ color: colors.textSecondary }}>
+                        {snippet.content}
+                      </div>
+                    </>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/stores/snippetStore.ts
+++ b/src/renderer/stores/snippetStore.ts
@@ -1,0 +1,161 @@
+import { create } from 'zustand'
+import { useSessionStore } from './sessionStore'
+
+export interface Snippet {
+  id: string
+  name: string
+  command: string
+  content: string
+  createdAt: number
+  updatedAt: number
+}
+
+interface SnippetState {
+  snippets: Snippet[]
+  managerOpen: boolean
+  addSnippet: (name: string, command: string, content: string) => Snippet | null
+  updateSnippet: (id: string, updates: Partial<Pick<Snippet, 'name' | 'command' | 'content'>>) => boolean
+  deleteSnippet: (id: string) => void
+  openManager: () => void
+  closeManager: () => void
+}
+
+const STORAGE_KEY = 'clui-snippets'
+const BUILT_IN_COMMANDS = new Set([
+  '/clear',
+  '/focus',
+  '/claim',
+  '/done',
+  '/release',
+  '/memory',
+  '/cost',
+  '/model',
+  '/mcp',
+  '/skills',
+  '/help',
+])
+
+function loadSnippets(): Snippet[] {
+  try {
+    if (typeof localStorage === 'undefined') return []
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return []
+    const parsed = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    return parsed.flatMap((entry) => {
+      if (!entry || typeof entry !== 'object') return []
+      const rawSnippet = entry as Partial<Snippet>
+      if (typeof rawSnippet.id !== 'string' || typeof rawSnippet.name !== 'string' || typeof rawSnippet.command !== 'string' || typeof rawSnippet.content !== 'string') {
+        return []
+      }
+      return [{
+        id: rawSnippet.id,
+        name: rawSnippet.name.trim(),
+        command: normalizeCommand(rawSnippet.command),
+        content: rawSnippet.content,
+        createdAt: typeof rawSnippet.createdAt === 'number' ? rawSnippet.createdAt : Date.now(),
+        updatedAt: typeof rawSnippet.updatedAt === 'number' ? rawSnippet.updatedAt : Date.now(),
+      }]
+    })
+  } catch {
+    return []
+  }
+}
+
+function saveSnippets(snippets: Snippet[]): void {
+  try {
+    if (typeof localStorage === 'undefined') return
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(snippets))
+  } catch {}
+}
+
+function normalizeCommand(command: string): string {
+  const trimmed = command.trim()
+  if (!trimmed) return '/'
+  return trimmed.startsWith('/') ? trimmed : `/${trimmed}`
+}
+
+function isValidCommand(command: string): boolean {
+  return /^\/[a-zA-Z0-9-]+$/.test(command)
+}
+
+function collides(command: string, snippets: Snippet[], currentId?: string): boolean {
+  if (BUILT_IN_COMMANDS.has(command)) {
+    return true
+  }
+  const skillCommands = new Set(
+    useSessionStore.getState().tabs.flatMap((tab) =>
+      (tab.sessionSkills || []).map((skill) => `/${skill}`.toLowerCase()),
+    ),
+  )
+  if (skillCommands.has(command.toLowerCase())) {
+    return true
+  }
+  return snippets.some((snippet) => snippet.command === command && snippet.id !== currentId)
+}
+
+const initialSnippets = loadSnippets()
+
+export const useSnippetStore = create<SnippetState>((set, get) => ({
+  snippets: initialSnippets,
+  managerOpen: false,
+
+  addSnippet: (name, command, content) => {
+    const nextCommand = normalizeCommand(command)
+    const nextName = name.trim()
+    const nextContent = content.trim()
+    if (!nextName || !nextContent || !isValidCommand(nextCommand) || collides(nextCommand, get().snippets)) {
+      return null
+    }
+
+    const snippet: Snippet = {
+      id: crypto.randomUUID(),
+      name: nextName,
+      command: nextCommand,
+      content: nextContent,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    }
+
+    const snippets = [...get().snippets, snippet].sort((a, b) => b.updatedAt - a.updatedAt)
+    saveSnippets(snippets)
+    set({ snippets })
+    return snippet
+  },
+
+  updateSnippet: (id, updates) => {
+    const current = get().snippets.find((snippet) => snippet.id === id)
+    if (!current) return false
+
+    const nextName = (updates.name ?? current.name).trim()
+    const nextCommand = normalizeCommand(updates.command ?? current.command)
+    const nextContent = (updates.content ?? current.content).trim()
+
+    if (!nextName || !nextContent || !isValidCommand(nextCommand) || collides(nextCommand, get().snippets, id)) {
+      return false
+    }
+
+    const snippets = get().snippets
+      .map((snippet) => snippet.id === id ? {
+        ...snippet,
+        name: nextName,
+        command: nextCommand,
+        content: nextContent,
+        updatedAt: Date.now(),
+      } : snippet)
+      .sort((a, b) => b.updatedAt - a.updatedAt)
+
+    saveSnippets(snippets)
+    set({ snippets })
+    return true
+  },
+
+  deleteSnippet: (id) => {
+    const snippets = get().snippets.filter((snippet) => snippet.id !== id)
+    saveSnippets(snippets)
+    set({ snippets })
+  },
+
+  openManager: () => set({ managerOpen: true }),
+  closeManager: () => set({ managerOpen: false }),
+}))

--- a/tests/unit/snippet-store.test.ts
+++ b/tests/unit/snippet-store.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockSessionState = vi.hoisted(() => ({
+  tabs: [] as Array<{ sessionSkills?: string[] }>,
+}))
+
+vi.mock('../../src/renderer/stores/sessionStore', () => ({
+  useSessionStore: {
+    getState: () => ({ tabs: mockSessionState.tabs }),
+  },
+}))
+
+class MemoryStorage implements Storage {
+  private map = new Map<string, string>()
+
+  get length(): number {
+    return this.map.size
+  }
+
+  clear(): void {
+    this.map.clear()
+  }
+
+  getItem(key: string): string | null {
+    return this.map.has(key) ? this.map.get(key)! : null
+  }
+
+  key(index: number): string | null {
+    return Array.from(this.map.keys())[index] ?? null
+  }
+
+  removeItem(key: string): void {
+    this.map.delete(key)
+  }
+
+  setItem(key: string, value: string): void {
+    this.map.set(key, value)
+  }
+}
+
+async function loadSnippetStore() {
+  return import('../../src/renderer/stores/snippetStore')
+}
+
+describe('snippetStore', () => {
+  let storage: MemoryStorage
+
+  beforeEach(() => {
+    vi.resetModules()
+    mockSessionState.tabs = []
+    storage = new MemoryStorage()
+    Object.defineProperty(globalThis, 'localStorage', {
+      value: storage,
+      configurable: true,
+      writable: true,
+    })
+  })
+
+  afterEach(() => {
+    Reflect.deleteProperty(globalThis, 'localStorage')
+    mockSessionState.tabs = []
+  })
+
+  it('adds snippets and persists them to localStorage', async () => {
+    const { useSnippetStore } = await loadSnippetStore()
+
+    const created = useSnippetStore.getState().addSnippet('Code Review', 'review', 'Review this code for bugs.')
+
+    expect(created).not.toBeNull()
+    expect(created?.command).toBe('/review')
+    expect(useSnippetStore.getState().snippets).toHaveLength(1)
+
+    const persisted = JSON.parse(storage.getItem('clui-snippets') || '[]')
+    expect(persisted).toHaveLength(1)
+    expect(persisted[0]).toMatchObject({
+      name: 'Code Review',
+      command: '/review',
+      content: 'Review this code for bugs.',
+    })
+  })
+
+  it('loads persisted snippets on initialization', async () => {
+    storage.setItem('clui-snippets', JSON.stringify([{
+      id: 'snippet-1',
+      name: 'Explain',
+      command: 'explain',
+      content: 'Explain this file in plain English.',
+      createdAt: 10,
+      updatedAt: 20,
+    }]))
+
+    const { useSnippetStore } = await loadSnippetStore()
+
+    expect(useSnippetStore.getState().snippets).toEqual([{
+      id: 'snippet-1',
+      name: 'Explain',
+      command: '/explain',
+      content: 'Explain this file in plain English.',
+      createdAt: 10,
+      updatedAt: 20,
+    }])
+  })
+
+  it('rejects built-in, duplicate, and skill-colliding commands', async () => {
+    mockSessionState.tabs = [{ sessionSkills: ['review'] }]
+    const { useSnippetStore } = await loadSnippetStore()
+
+    expect(useSnippetStore.getState().addSnippet('Help', 'help', 'Show commands.')).toBeNull()
+    expect(useSnippetStore.getState().addSnippet('Skill Review', 'review', 'Run the review skill.')).toBeNull()
+
+    const created = useSnippetStore.getState().addSnippet('Tests', 'tests', 'Generate tests for this file.')
+    expect(created).not.toBeNull()
+    expect(useSnippetStore.getState().addSnippet('Duplicate', '/tests', 'Something else.')).toBeNull()
+  })
+
+  it('updates and deletes snippets', async () => {
+    const { useSnippetStore } = await loadSnippetStore()
+    const created = useSnippetStore.getState().addSnippet('Explain', 'explain', 'Explain this change.')
+    expect(created).not.toBeNull()
+
+    const updated = useSnippetStore.getState().updateSnippet(created!.id, {
+      name: 'Generate Tests',
+      command: 'tests',
+      content: 'Write unit tests for this code.',
+    })
+
+    expect(updated).toBe(true)
+    expect(useSnippetStore.getState().snippets[0]).toMatchObject({
+      id: created!.id,
+      name: 'Generate Tests',
+      command: '/tests',
+      content: 'Write unit tests for this code.',
+    })
+
+    useSnippetStore.getState().deleteSnippet(created!.id)
+    expect(useSnippetStore.getState().snippets).toEqual([])
+    expect(storage.getItem('clui-snippets')).toBe('[]')
+  })
+})


### PR DESCRIPTION
## Summary
- add a renderer-side snippet store with localStorage persistence and command collision checks
- add a snippets manager panel from settings for creating, editing, searching, and deleting templates
- wire snippets into the slash command menu so selecting one fills the composer without auto-sending

## Validation
- npm run test
- npm run build

Closes #35