### PR TITLE
FEAT-010: Add session export dialog

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -15,8 +15,9 @@ import { buildScreenshotCommand, getScreenshotTempPath } from './screenshot'
 import { SettingsManager } from './settings-manager'
 import { AgentMemory } from './agent-memory'
 import { PinnedSessionStore } from './pinned-sessions'
+import { exportSessionToFile } from './session-export'
 import { IPC } from '../shared/types'
-import type { RunOptions, NormalizedEvent, EnrichedError } from '../shared/types'
+import type { RunOptions, NormalizedEvent, EnrichedError, ExportOptions, SessionExportData } from '../shared/types'
 
 const DEBUG_MODE = process.env.CLUI_DEBUG === '1'
 const SPACES_DEBUG = DEBUG_MODE || process.env.CLUI_SPACES_DEBUG === '1'
@@ -507,6 +508,14 @@ ipcMain.handle(IPC.LOAD_SESSION, async (_e, arg: { sessionId: string; projectPat
     return []
   }
 })
+
+ipcMain.handle(
+  IPC.EXPORT_SESSION,
+  async (_event, { data, options }: { data: SessionExportData; options: ExportOptions }) => {
+    log(`IPC EXPORT_SESSION ${data.sessionId || data.title}`)
+    return exportSessionToFile(mainWindow, data, options)
+  },
+)
 
 ipcMain.handle(IPC.AGENT_MEMORY_GET, (_event, projectPath: string) => {
   log(`IPC AGENT_MEMORY_GET: ${projectPath}`)

--- a/src/main/session-export.ts
+++ b/src/main/session-export.ts
@@ -1,0 +1,56 @@
+import { dialog, type BrowserWindow } from 'electron'
+import { existsSync } from 'fs'
+import { writeFile } from 'fs/promises'
+import { homedir } from 'os'
+import { join } from 'path'
+import { buildSessionExportContent } from '../shared/session-export'
+import type { ExportOptions, SessionExportData, SessionExportResult } from '../shared/types'
+
+export async function exportSessionToFile(
+  mainWindow: BrowserWindow | null,
+  data: SessionExportData,
+  options: ExportOptions,
+): Promise<SessionExportResult> {
+  try {
+    const extension = options.format === 'json' ? 'json' : 'md'
+    const content = buildSessionExportContent(data, options)
+    const fileName = `${slugify(data.title || data.sessionId || 'session-export')}.${extension}`
+    const defaultDir = existsSync(data.projectPath) ? data.projectPath : homedir()
+    const dialogOptions = {
+      title: 'Export Session',
+      defaultPath: join(defaultDir, fileName),
+      filters: [
+        options.format === 'json'
+          ? { name: 'JSON', extensions: ['json'] }
+          : { name: 'Markdown', extensions: ['md'] },
+      ],
+    }
+
+    const result = process.platform === 'darwin' || !mainWindow
+      ? await dialog.showSaveDialog(dialogOptions)
+      : await dialog.showSaveDialog(mainWindow, dialogOptions)
+
+    if (result.canceled || !result.filePath) {
+      return { ok: true, path: null }
+    }
+
+    await writeFile(result.filePath, content, 'utf8')
+    return { ok: true, path: result.filePath }
+  } catch (error) {
+    return {
+      ok: false,
+      path: null,
+      error: error instanceof Error ? error.message : String(error),
+    }
+  }
+}
+
+function slugify(value: string): string {
+  const normalized = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+
+  return normalized || 'session-export'
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -11,6 +11,9 @@ import type {
   SessionLoadMessage,
   AgentMemorySnapshot,
   AgentMemoryClaimResult,
+  ExportOptions,
+  SessionExportData,
+  SessionExportResult,
 } from '../shared/types'
 
 export interface CluiAPI {
@@ -37,6 +40,7 @@ export interface CluiAPI {
   resetTabSession(tabId: string): void
   listSessions(projectPath?: string): Promise<SessionMeta[]>
   loadSession(sessionId: string, projectPath?: string): Promise<SessionLoadMessage[]>
+  exportSession(data: SessionExportData, options: ExportOptions): Promise<SessionExportResult>
   pinSession(sessionId: string, projectPath: string): Promise<boolean>
   unpinSession(sessionId: string): Promise<boolean>
   agentMemoryGet(projectPath: string): Promise<AgentMemorySnapshot>
@@ -100,6 +104,7 @@ const api: CluiAPI = {
   resetTabSession: (tabId) => ipcRenderer.send(IPC.RESET_TAB_SESSION, tabId),
   listSessions: (projectPath?: string) => ipcRenderer.invoke(IPC.LIST_SESSIONS, projectPath),
   loadSession: (sessionId: string, projectPath?: string) => ipcRenderer.invoke(IPC.LOAD_SESSION, { sessionId, projectPath }),
+  exportSession: (data, options) => ipcRenderer.invoke(IPC.EXPORT_SESSION, { data, options }),
   pinSession: (sessionId, projectPath) => ipcRenderer.invoke(IPC.PIN_SESSION, { sessionId, projectPath }),
   unpinSession: (sessionId) => ipcRenderer.invoke(IPC.UNPIN_SESSION, sessionId),
   agentMemoryGet: (projectPath) => ipcRenderer.invoke(IPC.AGENT_MEMORY_GET, projectPath),

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -7,10 +7,12 @@ import { InputBar } from './components/InputBar'
 import { StatusBar } from './components/StatusBar'
 import { MarketplacePanel } from './components/MarketplacePanel'
 import { SnippetManager } from './components/SnippetManager'
+import { ExportDialog } from './components/ExportDialog'
 import { PermissionWizard } from './components/PermissionWizard'
 import { PopoverLayerProvider } from './components/PopoverLayer'
 import { useClaudeEvents } from './hooks/useClaudeEvents'
 import { useHealthReconciliation } from './hooks/useHealthReconciliation'
+import { useExportStore } from './stores/exportStore'
 import { useSessionStore } from './stores/sessionStore'
 import { useSnippetStore } from './stores/snippetStore'
 import { useColors, useThemeStore, spacing } from './theme'
@@ -105,6 +107,7 @@ export default function App() {
   const isExpanded = useSessionStore((s) => s.isExpanded)
   const marketplaceOpen = useSessionStore((s) => s.marketplaceOpen)
   const snippetManagerOpen = useSnippetStore((s) => s.managerOpen)
+  const exportDialogOpen = useExportStore((s) => s.isOpen)
   const isRunning = activeTabStatus === 'running' || activeTabStatus === 'connecting'
 
   // Layout dimensions — expandedUI widens and heightens the panel
@@ -206,6 +209,41 @@ export default function App() {
                     }}
                   >
                     <SnippetManager />
+                  </div>
+                </motion.div>
+              </div>
+            )}
+          </AnimatePresence>
+
+          <AnimatePresence initial={false}>
+            {exportDialogOpen && (
+              <div
+                data-clui-ui
+                style={{
+                  width: expandedUI ? 720 : 560,
+                  maxWidth: expandedUI ? 720 : 560,
+                  marginLeft: '50%',
+                  transform: 'translateX(-50%)',
+                  marginBottom: 14,
+                  position: 'relative',
+                  zIndex: 31,
+                }}
+              >
+                <motion.div
+                  initial={{ opacity: 0, y: 14, scale: 0.98 }}
+                  animate={{ opacity: 1, y: 0, scale: 1 }}
+                  exit={{ opacity: 0, y: 10, scale: 0.985 }}
+                  transition={TRANSITION}
+                >
+                  <div
+                    data-clui-ui
+                    className="glass-surface overflow-hidden no-drag"
+                    style={{
+                      borderRadius: 24,
+                      maxHeight: 500,
+                    }}
+                  >
+                    <ExportDialog />
                   </div>
                 </motion.div>
               </div>

--- a/src/renderer/components/ExportDialog.tsx
+++ b/src/renderer/components/ExportDialog.tsx
@@ -1,0 +1,219 @@
+import React, { useMemo, useState } from 'react'
+import { DownloadSimple, FileCode, BracketsCurly, X } from '@phosphor-icons/react'
+import { buildSessionExportContent, getFilteredExportMessages } from '../../shared/session-export'
+import { useColors } from '../theme'
+import { useExportStore } from '../stores/exportStore'
+import { useSessionStore } from '../stores/sessionStore'
+
+function ToggleRow({
+  label,
+  checked,
+  onChange,
+  colors,
+}: {
+  label: string
+  checked: boolean
+  onChange: (next: boolean) => void
+  colors: ReturnType<typeof useColors>
+}) {
+  return (
+    <label className="flex items-center gap-2 text-[12px]" style={{ color: colors.textSecondary }}>
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(event) => onChange(event.target.checked)}
+      />
+      <span>{label}</span>
+    </label>
+  )
+}
+
+export function ExportDialog() {
+  const colors = useColors()
+  const data = useExportStore((s) => s.data)
+  const options = useExportStore((s) => s.options)
+  const error = useExportStore((s) => s.error)
+  const closeDialog = useExportStore((s) => s.closeDialog)
+  const setOptions = useExportStore((s) => s.setOptions)
+  const setError = useExportStore((s) => s.setError)
+  const addSystemMessage = useSessionStore((s) => s.addSystemMessage)
+  const [isSaving, setIsSaving] = useState(false)
+
+  const filteredMessages = useMemo(
+    () => (data ? getFilteredExportMessages(data.messages, options) : []),
+    [data, options],
+  )
+  const preview = useMemo(
+    () => (data ? buildSessionExportContent(data, options) : ''),
+    [data, options],
+  )
+
+  if (!data) return null
+
+  const handleExport = async () => {
+    if (filteredMessages.length === 0) {
+      setError('Nothing to export with the current filters.')
+      return
+    }
+
+    setIsSaving(true)
+    setError(null)
+    const result = await window.clui.exportSession(data, options)
+    setIsSaving(false)
+
+    if (!result.ok) {
+      setError(result.error || 'Failed to export session.')
+      return
+    }
+
+    if (!result.path) {
+      return
+    }
+
+    addSystemMessage(`Session exported to ${result.path}`)
+    closeDialog()
+  }
+
+  return (
+    <div
+      data-clui-ui
+      style={{
+        height: 500,
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          padding: '16px 18px 10px',
+          borderBottom: `1px solid ${colors.containerBorder}`,
+        }}
+      >
+        <div>
+          <div style={{ fontSize: 13, fontWeight: 700, color: colors.textPrimary }}>
+            Export Session
+          </div>
+          <div style={{ fontSize: 11, color: colors.textTertiary, marginTop: 2 }}>
+            {data.title || 'Untitled session'}
+          </div>
+        </div>
+        <button
+          onClick={closeDialog}
+          aria-label="Close export dialog"
+          className="w-7 h-7 rounded-full flex items-center justify-center"
+          style={{ color: colors.textTertiary }}
+          title="Close export dialog"
+        >
+          <X size={15} />
+        </button>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4" style={{ padding: 16, borderBottom: `1px solid ${colors.containerBorder}` }}>
+        <div>
+          <div className="text-[11px] font-medium mb-2" style={{ color: colors.textPrimary }}>
+            Format
+          </div>
+          <div className="grid gap-2">
+            <button
+              onClick={() => setOptions({ format: 'markdown' })}
+              className="rounded-xl px-3 py-2 text-[12px] flex items-center gap-2 text-left"
+              style={{
+                background: options.format === 'markdown' ? colors.accentLight : colors.surfacePrimary,
+                border: `1px solid ${options.format === 'markdown' ? colors.accent : colors.containerBorder}`,
+                color: options.format === 'markdown' ? colors.accent : colors.textPrimary,
+              }}
+            >
+              <FileCode size={14} />
+              Markdown (.md)
+            </button>
+            <button
+              onClick={() => setOptions({ format: 'json' })}
+              className="rounded-xl px-3 py-2 text-[12px] flex items-center gap-2 text-left"
+              style={{
+                background: options.format === 'json' ? colors.accentLight : colors.surfacePrimary,
+                border: `1px solid ${options.format === 'json' ? colors.accent : colors.containerBorder}`,
+                color: options.format === 'json' ? colors.accent : colors.textPrimary,
+              }}
+            >
+              <BracketsCurly size={14} />
+              JSON (.json)
+            </button>
+          </div>
+        </div>
+
+        <div>
+          <div className="text-[11px] font-medium mb-2" style={{ color: colors.textPrimary }}>
+            Include
+          </div>
+          <div className="grid gap-2">
+            <ToggleRow label="User messages" checked={options.includeUserMessages} onChange={(checked) => setOptions({ includeUserMessages: checked })} colors={colors} />
+            <ToggleRow label="Assistant responses" checked={options.includeAssistantMessages} onChange={(checked) => setOptions({ includeAssistantMessages: checked })} colors={colors} />
+            <ToggleRow label="Tool calls" checked={options.includeToolCalls} onChange={(checked) => setOptions({ includeToolCalls: checked })} colors={colors} />
+            <ToggleRow label="Cost and tokens" checked={options.includeMetadata} onChange={(checked) => setOptions({ includeMetadata: checked })} colors={colors} />
+          </div>
+        </div>
+      </div>
+
+      <div style={{ padding: 16, paddingBottom: 8 }}>
+        <div className="flex items-center justify-between">
+          <div className="text-[11px] font-medium" style={{ color: colors.textPrimary }}>
+            Preview
+          </div>
+          <div className="text-[10px]" style={{ color: colors.textTertiary }}>
+            {filteredMessages.length} item{filteredMessages.length !== 1 ? 's' : ''}
+          </div>
+        </div>
+      </div>
+
+      <div style={{ padding: '0 16px 16px', flex: 1, minHeight: 0 }}>
+        <pre
+          className="rounded-2xl p-3 text-[11px] whitespace-pre-wrap overflow-auto h-full"
+          style={{
+            margin: 0,
+            background: colors.surfacePrimary,
+            color: colors.textSecondary,
+            border: `1px solid ${colors.containerBorder}`,
+          }}
+        >
+          {filteredMessages.length === 0 ? 'Nothing to export with the current filters.' : preview}
+        </pre>
+      </div>
+
+      <div
+        className="flex items-center justify-between gap-3"
+        style={{
+          padding: '0 16px 16px',
+        }}
+      >
+        <div className="text-[11px]" style={{ color: error ? colors.statusError : colors.textTertiary }}>
+          {error || 'Export the current session to Markdown or JSON.'}
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={closeDialog}
+            className="rounded-xl px-3 py-2 text-[12px]"
+            style={{ color: colors.textSecondary, background: colors.surfaceSecondary }}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={() => void handleExport()}
+            disabled={isSaving}
+            className="rounded-xl px-3 py-2 text-[12px] font-medium flex items-center gap-2"
+            style={{
+              background: colors.accent,
+              color: colors.textOnAccent,
+              opacity: isSaving ? 0.7 : 1,
+            }}
+          >
+            <DownloadSimple size={14} />
+            {isSaving ? 'Exporting...' : 'Export'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/HistoryPicker.tsx
+++ b/src/renderer/components/HistoryPicker.tsx
@@ -1,11 +1,12 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react'
 import { createPortal } from 'react-dom'
 import { motion } from 'framer-motion'
-import { Clock, ChatCircle, PushPin } from '@phosphor-icons/react'
+import { Clock, ChatCircle, PushPin, DownloadSimple } from '@phosphor-icons/react'
+import { useExportStore } from '../stores/exportStore'
 import { useSessionStore } from '../stores/sessionStore'
 import { usePopoverLayer } from './PopoverLayer'
 import { useColors } from '../theme'
-import type { SessionMeta } from '../../shared/types'
+import type { Message, SessionMeta } from '../../shared/types'
 
 function formatTimeAgo(isoDate: string): string {
   const diff = Date.now() - new Date(isoDate).getTime()
@@ -25,8 +26,16 @@ function formatSize(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)}M`
 }
 
+function getSessionTitle(session: SessionMeta): string {
+  return session.firstMessage
+    ? (session.firstMessage.length > 30 ? session.firstMessage.substring(0, 27) + '...' : session.firstMessage)
+    : session.slug || 'Resumed'
+}
+
 export function HistoryPicker() {
   const resumeSession = useSessionStore((s) => s.resumeSession)
+  const addSystemMessage = useSessionStore((s) => s.addSystemMessage)
+  const openExportDialog = useExportStore((s) => s.openDialog)
   const isExpanded = useSessionStore((s) => s.isExpanded)
   const activeTab = useSessionStore(
     (s) => s.tabs.find((t) => t.id === s.activeTabId),
@@ -97,10 +106,40 @@ export function HistoryPicker() {
 
   const handleSelect = (session: SessionMeta) => {
     setOpen(false)
-    const title = session.firstMessage
-      ? (session.firstMessage.length > 30 ? session.firstMessage.substring(0, 27) + '...' : session.firstMessage)
-      : session.slug || 'Resumed'
-    void resumeSession(session.sessionId, title, effectiveProjectPath)
+    void resumeSession(session.sessionId, getSessionTitle(session), effectiveProjectPath)
+  }
+
+  const handleExportSession = async (session: SessionMeta, event: React.MouseEvent) => {
+    event.stopPropagation()
+    try {
+      const history = await window.clui.loadSession(session.sessionId, effectiveProjectPath)
+      if (history.length === 0) {
+        addSystemMessage('Nothing to export for that session.')
+        return
+      }
+
+      const messages: Message[] = history.map((message) => ({
+        id: `${session.sessionId}-${message.timestamp}-${message.role}`,
+        role: message.role as Message['role'],
+        content: message.content,
+        toolName: message.toolName,
+        toolStatus: message.toolName ? 'completed' : undefined,
+        timestamp: message.timestamp,
+      }))
+
+      openExportDialog({
+        title: getSessionTitle(session),
+        exportedAt: new Date().toISOString(),
+        sessionId: session.sessionId,
+        projectPath: effectiveProjectPath,
+        model: null,
+        messages,
+        lastResult: null,
+      })
+      setOpen(false)
+    } catch {
+      addSystemMessage('Failed to load that session for export.')
+    }
   }
 
   const handleTogglePin = async (session: SessionMeta, event: React.MouseEvent) => {
@@ -204,14 +243,24 @@ export function HistoryPicker() {
                         </div>
                       </div>
                     </button>
-                    <button
-                      onClick={(event) => void handleTogglePin(session, event)}
-                      className="flex-shrink-0 mt-0.5"
-                      style={{ color: colors.accent }}
-                      title="Unpin session"
-                    >
-                      <PushPin size={13} weight="fill" />
-                    </button>
+                    <div className="flex items-center gap-1 flex-shrink-0 mt-0.5">
+                      <button
+                        onClick={(event) => void handleExportSession(session, event)}
+                        className="flex-shrink-0"
+                        style={{ color: colors.textTertiary }}
+                        title="Export session"
+                      >
+                        <DownloadSimple size={13} />
+                      </button>
+                      <button
+                        onClick={(event) => void handleTogglePin(session, event)}
+                        className="flex-shrink-0"
+                        style={{ color: colors.accent }}
+                        title="Unpin session"
+                      >
+                        <PushPin size={13} weight="fill" />
+                      </button>
+                    </div>
                   </div>
                 ))}
                 <div className="mx-3 my-1" style={{ height: 1, background: colors.popoverBorder }} />
@@ -247,14 +296,24 @@ export function HistoryPicker() {
                         </div>
                       </div>
                     </button>
-                    <button
-                      onClick={(event) => void handleTogglePin(session, event)}
-                      className="flex-shrink-0 mt-0.5"
-                      style={{ color: colors.textTertiary }}
-                      title="Pin session"
-                    >
-                      <PushPin size={13} />
-                    </button>
+                    <div className="flex items-center gap-1 flex-shrink-0 mt-0.5">
+                      <button
+                        onClick={(event) => void handleExportSession(session, event)}
+                        className="flex-shrink-0"
+                        style={{ color: colors.textTertiary }}
+                        title="Export session"
+                      >
+                        <DownloadSimple size={13} />
+                      </button>
+                      <button
+                        onClick={(event) => void handleTogglePin(session, event)}
+                        className="flex-shrink-0"
+                        style={{ color: colors.textTertiary }}
+                        title="Pin session"
+                      >
+                        <PushPin size={13} />
+                      </button>
+                    </div>
                   </div>
                 ))}
               </>

--- a/src/renderer/components/InputBar.tsx
+++ b/src/renderer/components/InputBar.tsx
@@ -2,11 +2,12 @@ import React, { useState, useRef, useCallback, useEffect, useLayoutEffect } from
 import { motion, AnimatePresence } from 'framer-motion'
 import { Microphone, ArrowUp, SpinnerGap, X, Check, Sparkle, Lightning } from '@phosphor-icons/react'
 import { useSessionStore, AVAILABLE_MODELS } from '../stores/sessionStore'
+import { useExportStore } from '../stores/exportStore'
 import { useSnippetStore } from '../stores/snippetStore'
 import { AttachmentChips } from './AttachmentChips'
 import { SlashCommandMenu, getFilteredCommandsWithExtras, type SlashCommand } from './SlashCommandMenu'
 import { useColors } from '../theme'
-import type { AgentAssignment, AgentMemorySnapshot } from '../../shared/types'
+import type { AgentAssignment, AgentMemorySnapshot, SessionExportData } from '../../shared/types'
 
 const INPUT_MIN_HEIGHT = 20
 const INPUT_MAX_HEIGHT = 140
@@ -81,6 +82,7 @@ export function InputBar() {
   const releaseAgentWork = useSessionStore((s) => s.releaseAgentWork)
 
   const setPreferredModel = useSessionStore((s) => s.setPreferredModel)
+  const openExportDialog = useExportStore((s) => s.openDialog)
   const staticInfo = useSessionStore((s) => s.staticInfo)
   const agentMemorySnapshot = useSessionStore((s) => s.agentMemorySnapshot)
   const preferredModel = useSessionStore((s) => s.preferredModel)
@@ -118,6 +120,26 @@ export function InputBar() {
     })
     return unsub
   }, [])
+
+  const buildCurrentExportData = useCallback((): SessionExportData | null => {
+    if (!tab || tab.messages.length === 0) {
+      return null
+    }
+
+    const projectPath = tab.hasChosenDirectory
+      ? tab.workingDirectory
+      : (staticInfo?.homePath || tab.workingDirectory || '~')
+
+    return {
+      title: tab.title,
+      exportedAt: new Date().toISOString(),
+      sessionId: tab.claudeSessionId,
+      projectPath,
+      model: tab.sessionModel,
+      messages: tab.messages,
+      lastResult: tab.lastResult,
+    }
+  }, [tab, staticInfo])
 
   const measureInlineHeight = useCallback((value: string): number => {
     if (typeof document === 'undefined') return 0
@@ -221,6 +243,15 @@ export function InputBar() {
           addSystemMessage(formatMemorySnapshot(snapshot || agentMemorySnapshot, activeTabId))
         })
         break
+      case '/export': {
+        const exportData = buildCurrentExportData()
+        if (!exportData) {
+          addSystemMessage('Nothing to export in this session.')
+        } else {
+          openExportDialog(exportData)
+        }
+        break
+      }
       case '/cost': {
         if (tab?.lastResult) {
           const r = tab.lastResult
@@ -274,6 +305,7 @@ export function InputBar() {
       case '/help': {
         const lines = [
           '/clear — Clear conversation history',
+          '/export — Export this session to Markdown or JSON',
           '/cost — Show token usage and cost',
           '/model — Show model info & switch models',
           '/mcp — Show MCP server status',
@@ -284,7 +316,7 @@ export function InputBar() {
         break
       }
     }
-  }, [tab, clearTab, addSystemMessage, staticInfo, preferredModel, refreshAgentMemory, agentMemorySnapshot, activeTabId])
+  }, [tab, clearTab, addSystemMessage, staticInfo, preferredModel, refreshAgentMemory, agentMemorySnapshot, activeTabId, buildCurrentExportData, openExportDialog])
 
   const handleSlashSelect = useCallback((cmd: SlashCommand) => {
     const isSkillCommand = !!tab?.sessionSkills?.includes(cmd.command.replace(/^\//, ''))

--- a/src/renderer/components/SlashCommandMenu.tsx
+++ b/src/renderer/components/SlashCommandMenu.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from 'react'
 import { createPortal } from 'react-dom'
 import { motion } from 'framer-motion'
 import {
-  Trash, Cpu, CurrencyDollar, Question, HardDrives, Sparkle,
+  Trash, Cpu, CurrencyDollar, Question, HardDrives, Sparkle, Export,
 } from '@phosphor-icons/react'
 import { usePopoverLayer } from './PopoverLayer'
 import { useColors } from '../theme'
@@ -23,6 +23,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { command: '/done', description: 'Mark the current work as done', icon: <Question size={13} />, insertOnly: true },
   { command: '/release', description: 'Release the current claim', icon: <Trash size={13} />, insertOnly: true },
   { command: '/memory', description: 'Show active and recent shared work', icon: <HardDrives size={13} /> },
+  { command: '/export', description: 'Export this session to Markdown or JSON', icon: <Export size={13} /> },
   { command: '/cost', description: 'Show token usage and cost', icon: <CurrencyDollar size={13} /> },
   { command: '/model', description: 'Show current model info', icon: <Cpu size={13} /> },
   { command: '/mcp', description: 'Show MCP server status', icon: <HardDrives size={13} /> },

--- a/src/renderer/stores/exportStore.ts
+++ b/src/renderer/stores/exportStore.ts
@@ -1,0 +1,43 @@
+import { create } from 'zustand'
+import { DEFAULT_EXPORT_OPTIONS } from '../../shared/session-export'
+import type { ExportOptions, SessionExportData } from '../../shared/types'
+
+interface ExportState {
+  isOpen: boolean
+  data: SessionExportData | null
+  options: ExportOptions
+  error: string | null
+  openDialog: (data: SessionExportData) => void
+  closeDialog: () => void
+  setOptions: (updates: Partial<ExportOptions>) => void
+  setError: (error: string | null) => void
+}
+
+export const useExportStore = create<ExportState>((set) => ({
+  isOpen: false,
+  data: null,
+  options: DEFAULT_EXPORT_OPTIONS,
+  error: null,
+
+  openDialog: (data) => set({
+    isOpen: true,
+    data,
+    options: DEFAULT_EXPORT_OPTIONS,
+    error: null,
+  }),
+
+  closeDialog: () => set({
+    isOpen: false,
+    data: null,
+    error: null,
+  }),
+
+  setOptions: (updates) => set((state) => ({
+    options: {
+      ...state.options,
+      ...updates,
+    },
+  })),
+
+  setError: (error) => set({ error }),
+}))

--- a/src/renderer/stores/snippetStore.ts
+++ b/src/renderer/stores/snippetStore.ts
@@ -28,6 +28,7 @@ const BUILT_IN_COMMANDS = new Set([
   '/done',
   '/release',
   '/memory',
+  '/export',
   '/cost',
   '/model',
   '/mcp',

--- a/src/shared/session-export.ts
+++ b/src/shared/session-export.ts
@@ -1,0 +1,147 @@
+import type { ExportOptions, Message, SessionExportData } from './types'
+
+export const DEFAULT_EXPORT_OPTIONS: ExportOptions = {
+  format: 'markdown',
+  includeUserMessages: true,
+  includeAssistantMessages: true,
+  includeToolCalls: true,
+  includeMetadata: false,
+}
+
+export function getFilteredExportMessages(messages: Message[], options: ExportOptions): Message[] {
+  return messages.filter((message) => {
+    if (message.role === 'user') return options.includeUserMessages
+    if (message.role === 'assistant' || message.role === 'system') return options.includeAssistantMessages
+    if (message.role === 'tool') return options.includeToolCalls
+    return false
+  })
+}
+
+export function hasExportableMessages(data: SessionExportData, options: ExportOptions): boolean {
+  return getFilteredExportMessages(data.messages, options).length > 0
+}
+
+export function buildSessionExportContent(data: SessionExportData, options: ExportOptions): string {
+  return options.format === 'json'
+    ? buildJsonExport(data, options)
+    : buildMarkdownExport(data, options)
+}
+
+function buildMarkdownExport(data: SessionExportData, options: ExportOptions): string {
+  const filteredMessages = getFilteredExportMessages(data.messages, options)
+  const title = getExportTitle(data)
+  const lines: string[] = [`# Session: ${title}`]
+
+  const metaParts = [`Exported: ${new Date(data.exportedAt).toLocaleString()}`]
+  if (data.model) {
+    metaParts.push(`Model: ${data.model}`)
+  }
+  if (options.includeMetadata && data.lastResult) {
+    metaParts.push(`Cost: $${data.lastResult.totalCostUsd.toFixed(4)}`)
+    metaParts.push(`Duration: ${formatDuration(data.lastResult.durationMs)}`)
+    metaParts.push(`Turns: ${data.lastResult.numTurns}`)
+    if (data.lastResult.usage.input_tokens || data.lastResult.usage.output_tokens) {
+      metaParts.push(
+        `Tokens: ${(data.lastResult.usage.input_tokens || 0).toLocaleString()} in / ${(data.lastResult.usage.output_tokens || 0).toLocaleString()} out`,
+      )
+    }
+  }
+
+  lines.push(`*${metaParts.join(' | ')}*`)
+  lines.push('')
+  lines.push('---')
+  lines.push('')
+
+  if (filteredMessages.length === 0) {
+    lines.push('Nothing to export.')
+    return `${lines.join('\n').trim()}\n`
+  }
+
+  filteredMessages.forEach((message, index) => {
+    if (message.role === 'user') {
+      lines.push('## User')
+      lines.push(message.content.trim() || '(empty)')
+    } else if (message.role === 'assistant') {
+      lines.push('## Assistant')
+      lines.push(message.content.trim() || '(empty)')
+    } else if (message.role === 'system') {
+      lines.push('## System')
+      lines.push(message.content.trim() || '(empty)')
+    } else if (message.role === 'tool') {
+      lines.push(`### Tool: ${message.toolName || 'Tool'}`)
+      if (message.toolInput?.trim()) {
+        lines.push('```json')
+        lines.push(message.toolInput.trim())
+        lines.push('```')
+      }
+      if (message.content.trim()) {
+        lines.push(message.content.trim())
+      }
+      if (!message.toolInput?.trim() && !message.content.trim()) {
+        lines.push('(no output captured)')
+      }
+    }
+
+    if (index < filteredMessages.length - 1) {
+      lines.push('')
+      lines.push('---')
+      lines.push('')
+    }
+  })
+
+  return `${lines.join('\n').trim()}\n`
+}
+
+function buildJsonExport(data: SessionExportData, options: ExportOptions): string {
+  const filteredMessages = getFilteredExportMessages(data.messages, options)
+  const payload: Record<string, unknown> = {
+    exportedAt: data.exportedAt,
+    title: getExportTitle(data),
+    sessionId: data.sessionId,
+    model: data.model,
+    projectPath: data.projectPath,
+    messages: filteredMessages.map((message) => ({
+      role: message.role,
+      content: message.content,
+      toolName: message.toolName,
+      toolInput: message.toolInput,
+      toolStatus: message.toolStatus,
+      timestamp: new Date(message.timestamp).toISOString(),
+    })),
+  }
+
+  if (options.includeMetadata && data.lastResult) {
+    payload.metadata = {
+      totalCostUsd: data.lastResult.totalCostUsd,
+      durationMs: data.lastResult.durationMs,
+      numTurns: data.lastResult.numTurns,
+      usage: data.lastResult.usage,
+    }
+  }
+
+  return `${JSON.stringify(payload, null, 2)}\n`
+}
+
+function getExportTitle(data: SessionExportData): string {
+  const trimmedTitle = data.title.trim()
+  if (trimmedTitle) {
+    return trimmedTitle
+  }
+
+  const firstUserMessage = data.messages.find((message) => message.role === 'user' && message.content.trim())
+  if (firstUserMessage) {
+    const normalized = firstUserMessage.content.replace(/\s+/g, ' ').trim()
+    return normalized.length > 60 ? `${normalized.slice(0, 57).trimEnd()}...` : normalized
+  }
+
+  return data.sessionId ? `Session ${data.sessionId.slice(0, 8)}` : 'Untitled Session'
+}
+
+function formatDuration(durationMs: number): string {
+  if (durationMs < 1000) return `${durationMs}ms`
+  const totalSeconds = Math.round(durationMs / 1000)
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+  if (minutes === 0) return `${totalSeconds}s`
+  return `${minutes}m ${seconds}s`
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -227,6 +227,32 @@ export interface RunResult {
   sessionId: string
 }
 
+export type ExportFormat = 'markdown' | 'json'
+
+export interface ExportOptions {
+  format: ExportFormat
+  includeUserMessages: boolean
+  includeAssistantMessages: boolean
+  includeToolCalls: boolean
+  includeMetadata: boolean
+}
+
+export interface SessionExportData {
+  title: string
+  exportedAt: string
+  sessionId: string | null
+  projectPath: string
+  model: string | null
+  messages: Message[]
+  lastResult: RunResult | null
+}
+
+export interface SessionExportResult {
+  ok: boolean
+  path: string | null
+  error?: string
+}
+
 // ─── Canonical Events (normalized from raw stream) ───
 
 export type NormalizedEvent =
@@ -359,6 +385,7 @@ export const IPC = {
   ANIMATE_HEIGHT: 'clui:animate-height',
   LIST_SESSIONS: 'clui:list-sessions',
   LOAD_SESSION: 'clui:load-session',
+  EXPORT_SESSION: 'clui:export-session',
   AGENT_MEMORY_GET: 'clui:agent-memory-get',
   AGENT_MEMORY_FOCUS: 'clui:agent-memory-focus',
   AGENT_MEMORY_CLAIM: 'clui:agent-memory-claim',

--- a/tests/unit/session-export.test.ts
+++ b/tests/unit/session-export.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import { buildSessionExportContent, DEFAULT_EXPORT_OPTIONS, getFilteredExportMessages, hasExportableMessages } from '../../src/shared/session-export'
+import type { SessionExportData } from '../../src/shared/types'
+
+const sampleData: SessionExportData = {
+  title: 'API refactor review',
+  exportedAt: '2026-03-18T14:00:00.000Z',
+  sessionId: 'session-12345678',
+  projectPath: 'C:/repo',
+  model: 'claude-sonnet-4-6',
+  messages: [
+    { id: '1', role: 'user', content: 'Review this file for bugs.', timestamp: 1 },
+    { id: '2', role: 'assistant', content: 'I found two problems.', timestamp: 2 },
+    { id: '3', role: 'tool', content: '', toolName: 'Edit', toolInput: '{\"file\":\"src/app.ts\"}', toolStatus: 'completed', timestamp: 3 },
+    { id: '4', role: 'system', content: 'Export ready.', timestamp: 4 },
+  ],
+  lastResult: {
+    totalCostUsd: 0.0123,
+    durationMs: 4200,
+    numTurns: 3,
+    usage: {
+      input_tokens: 100,
+      output_tokens: 50,
+    },
+    sessionId: 'session-12345678',
+  },
+}
+
+describe('session export formatter', () => {
+  it('filters messages according to export options', () => {
+    const filtered = getFilteredExportMessages(sampleData.messages, {
+      ...DEFAULT_EXPORT_OPTIONS,
+      includeToolCalls: false,
+    })
+
+    expect(filtered.map((message) => message.role)).toEqual(['user', 'assistant', 'system'])
+  })
+
+  it('builds markdown export with metadata and tool blocks', () => {
+    const content = buildSessionExportContent(sampleData, {
+      ...DEFAULT_EXPORT_OPTIONS,
+      includeMetadata: true,
+    })
+
+    expect(content).toContain('# Session: API refactor review')
+    expect(content).toContain('## User')
+    expect(content).toContain('## Assistant')
+    expect(content).toContain('### Tool: Edit')
+    expect(content).toContain('```json')
+    expect(content).toContain('Cost: $0.0123')
+  })
+
+  it('builds json export and omits metadata when disabled', () => {
+    const content = buildSessionExportContent(sampleData, {
+      ...DEFAULT_EXPORT_OPTIONS,
+      format: 'json',
+      includeMetadata: false,
+    })
+
+    const parsed = JSON.parse(content) as Record<string, unknown>
+    expect(parsed.title).toBe('API refactor review')
+    expect(parsed.model).toBe('claude-sonnet-4-6')
+    expect(parsed).not.toHaveProperty('metadata')
+    expect(Array.isArray(parsed.messages)).toBe(true)
+  })
+
+  it('detects when no messages remain after filtering', () => {
+    expect(hasExportableMessages(sampleData, {
+      ...DEFAULT_EXPORT_OPTIONS,
+      includeUserMessages: false,
+      includeAssistantMessages: false,
+      includeToolCalls: false,
+    })).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- add Markdown and JSON session export formatting plus an Electron save flow
- add an export dialog with preview and include toggles, opened via /export
- add history picker export actions and reserve /export from custom snippets

## Validation
- npm run test
- npm run build

Closes #44