### PR TITLE
FEAT-014: Inline Code Diff Viewer

### DIFF
--- a/src/renderer/components/ConversationView.tsx
+++ b/src/renderer/components/ConversationView.tsx
@@ -11,6 +11,7 @@ import { useSessionStore } from '../stores/sessionStore'
 import { PermissionCard } from './PermissionCard'
 import { PermissionDeniedCard } from './PermissionDeniedCard'
 import { RetryBanner } from './RetryBanner'
+import { DiffViewer } from './DiffViewer'
 import { useColors, useThemeStore } from '../theme'
 import type { Message } from '../../shared/types'
 
@@ -722,18 +723,8 @@ function ToolGroup({ tools, skipMotion }: { tools: Message[]; skipMotion?: boole
                       {desc}
                     </span>
 
-                    {/* Result badge */}
-                    {!isRunning && (
-                      <span
-                        className="inline-block text-[10px] mt-0.5 px-1.5 py-[1px] rounded"
-                        style={{
-                          background: tool.toolStatus === 'error' ? colors.statusErrorBg : colors.surfaceHover,
-                          color: tool.toolStatus === 'error' ? colors.statusError : colors.textMuted,
-                        }}
-                      >
-                        Result
-                      </span>
-                    )}
+                    {/* Inline diff viewer for Edit/Write tools */}
+                    {!isRunning && <ToolDiffOrBadge tool={tool} />}
 
                     {isRunning && (
                       <span className="text-[10px] mt-0.5 block" style={{ color: colors.textMuted }}>
@@ -844,6 +835,70 @@ function ToolIcon({ name, size = 12 }: { name: string; size?: number }) {
   return (
     <span className="flex items-center" style={{ color: colors.textTertiary }}>
       {ICONS[name] || <Wrench size={size} />}
+    </span>
+  )
+}
+
+// ─── Tool Diff or Badge — shows DiffViewer for Edit/Write, generic badge otherwise ───
+
+/** Try to parse tool input JSON safely */
+function parseToolInput(raw?: string): Record<string, unknown> | null {
+  if (!raw) return null
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>
+    }
+    return null
+  } catch {
+    return null
+  }
+}
+
+function ToolDiffOrBadge({ tool }: { tool: Message }) {
+  const colors = useColors()
+  const toolName = tool.toolName || ''
+  const parsed = useMemo(() => parseToolInput(tool.toolInput), [tool.toolInput])
+
+  // Edit tool: has file_path, old_string, new_string
+  if (toolName === 'Edit' && parsed) {
+    const filePath = typeof parsed.file_path === 'string' ? parsed.file_path : ''
+    const oldString = typeof parsed.old_string === 'string' ? parsed.old_string : ''
+    const newString = typeof parsed.new_string === 'string' ? parsed.new_string : ''
+
+    if (filePath && (oldString || newString)) {
+      return (
+        <div className="mt-1.5">
+          <DiffViewer filePath={filePath} oldString={oldString} newString={newString} />
+        </div>
+      )
+    }
+  }
+
+  // Write tool: has file_path, content (all additions, no old content)
+  if (toolName === 'Write' && parsed) {
+    const filePath = typeof parsed.file_path === 'string' ? parsed.file_path : ''
+    const content = typeof parsed.content === 'string' ? parsed.content : ''
+
+    if (filePath && content) {
+      return (
+        <div className="mt-1.5">
+          <DiffViewer filePath={filePath} oldString="" newString={content} />
+        </div>
+      )
+    }
+  }
+
+  // Fallback: generic result badge
+  return (
+    <span
+      className="inline-block text-[10px] mt-0.5 px-1.5 py-[1px] rounded"
+      style={{
+        background: tool.toolStatus === 'error' ? colors.statusErrorBg : colors.surfaceHover,
+        color: tool.toolStatus === 'error' ? colors.statusError : colors.textMuted,
+      }}
+    >
+      Result
     </span>
   )
 }

--- a/src/renderer/components/DiffViewer.tsx
+++ b/src/renderer/components/DiffViewer.tsx
@@ -1,0 +1,275 @@
+import React, { useState, useMemo } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+import { CaretDown, CaretRight } from '@phosphor-icons/react'
+import { useColors } from '../theme'
+import { generateDiff } from '../utils/diff'
+import type { DiffHunk, DiffLine } from '../utils/diff'
+
+// ─── Constants ───
+
+const LARGE_DIFF_THRESHOLD = 50
+const GUTTER_WIDTH = '4ch'
+const BORDER_WIDTH = 3
+
+// ─── Types ───
+
+export interface DiffViewerProps {
+  filePath: string
+  oldString: string
+  newString: string
+  defaultCollapsed?: boolean
+}
+
+// ─── Component ───
+
+export function DiffViewer({ filePath, oldString, newString, defaultCollapsed }: DiffViewerProps) {
+  const colors = useColors()
+
+  const hunks = useMemo(
+    () => generateDiff(oldString, newString),
+    [oldString, newString],
+  )
+
+  const totalLines = useMemo(
+    () => hunks.reduce((sum, h) => sum + h.lines.length, 0),
+    [hunks],
+  )
+
+  const { additions, deletions } = useMemo(() => {
+    let add = 0
+    let del = 0
+    for (const hunk of hunks) {
+      for (const line of hunk.lines) {
+        if (line.type === 'addition') add++
+        else if (line.type === 'deletion') del++
+      }
+    }
+    return { additions: add, deletions: del }
+  }, [hunks])
+
+  const isLarge = totalLines > LARGE_DIFF_THRESHOLD
+  const shouldStartCollapsed = defaultCollapsed ?? isLarge
+
+  const [collapsed, setCollapsed] = useState(shouldStartCollapsed)
+
+  // No diff — identical content
+  if (hunks.length === 0) return null
+
+  const fileName = filePath.split(/[/\\]/).pop() || filePath
+
+  return (
+    <div
+      style={{
+        borderRadius: 6,
+        border: `1px solid ${colors.toolBorder}`,
+        background: colors.codeBg,
+        overflow: 'hidden',
+        fontSize: 12,
+        fontFamily: 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace',
+      }}
+    >
+      {/* Header */}
+      <button
+        type="button"
+        onClick={() => setCollapsed(!collapsed)}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 6,
+          width: '100%',
+          padding: '6px 10px',
+          background: colors.surfacePrimary,
+          border: 'none',
+          borderBottom: collapsed ? 'none' : `1px solid ${colors.toolBorder}`,
+          cursor: 'pointer',
+          textAlign: 'left',
+          color: colors.textSecondary,
+          fontSize: 12,
+          fontFamily: 'inherit',
+        }}
+      >
+        {collapsed
+          ? <CaretRight size={12} style={{ color: colors.textTertiary, flexShrink: 0 }} />
+          : <CaretDown size={12} style={{ color: colors.textTertiary, flexShrink: 0 }} />
+        }
+        <span
+          style={{
+            color: colors.textSecondary,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+          title={filePath}
+        >
+          {fileName}
+        </span>
+        <span style={{ color: colors.textTertiary, fontSize: 11, flexShrink: 0 }}>
+          {collapsed ? `Show ${totalLines} lines changed` : ''}
+        </span>
+      </button>
+
+      {/* Diff body */}
+      <AnimatePresence initial={false}>
+        {!collapsed && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.15 }}
+            style={{ overflow: 'hidden' }}
+          >
+            <div style={{ overflowX: 'auto' }}>
+              {hunks.map((hunk, hunkIdx) => (
+                <HunkBlock key={hunkIdx} hunk={hunk} colors={colors} showHeader={hunks.length > 1} />
+              ))}
+            </div>
+
+            {/* Summary footer */}
+            <div
+              style={{
+                padding: '4px 10px',
+                borderTop: `1px solid ${colors.toolBorder}`,
+                color: colors.textTertiary,
+                fontSize: 11,
+              }}
+            >
+              <span style={{ color: colors.diffAddedBorder }}>+{additions}</span>
+              {' '}
+              <span style={{ color: colors.diffRemovedBorder }}>-{deletions}</span>
+              {' lines changed'}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  )
+}
+
+// ─── Hunk block ───
+
+function HunkBlock({
+  hunk,
+  colors,
+  showHeader,
+}: {
+  hunk: DiffHunk
+  colors: ReturnType<typeof useColors>
+  showHeader: boolean
+}) {
+  const oldCount = hunk.lines.filter((l) => l.type !== 'addition').length
+  const newCount = hunk.lines.filter((l) => l.type !== 'deletion').length
+
+  return (
+    <div>
+      {showHeader && (
+        <div
+          style={{
+            padding: '2px 10px',
+            color: colors.diffHunkHeader,
+            fontStyle: 'italic',
+            fontSize: 11,
+            background: colors.surfacePrimary,
+            userSelect: 'none',
+          }}
+        >
+          @@ -{hunk.oldStart},{oldCount} +{hunk.newStart},{newCount} @@
+        </div>
+      )}
+      {hunk.lines.map((line, lineIdx) => (
+        <DiffLineRow key={lineIdx} line={line} colors={colors} />
+      ))}
+    </div>
+  )
+}
+
+// ─── Individual diff line ───
+
+function DiffLineRow({
+  line,
+  colors,
+}: {
+  line: DiffLine
+  colors: ReturnType<typeof useColors>
+}) {
+  const bgColor =
+    line.type === 'addition' ? colors.diffAddedBg :
+    line.type === 'deletion' ? colors.diffRemovedBg :
+    'transparent'
+
+  const borderColor =
+    line.type === 'addition' ? colors.diffAddedBorder :
+    line.type === 'deletion' ? colors.diffRemovedBorder :
+    'transparent'
+
+  const prefix =
+    line.type === 'addition' ? '+' :
+    line.type === 'deletion' ? '-' :
+    ' '
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        background: bgColor,
+        borderLeft: `${BORDER_WIDTH}px solid ${borderColor}`,
+        minHeight: 20,
+        lineHeight: '20px',
+      }}
+    >
+      {/* Old line number gutter */}
+      <span
+        style={{
+          width: GUTTER_WIDTH,
+          minWidth: GUTTER_WIDTH,
+          textAlign: 'right',
+          paddingRight: 4,
+          color: colors.textMuted,
+          userSelect: 'none',
+          fontSize: 11,
+        }}
+      >
+        {line.oldLineNum ?? ''}
+      </span>
+
+      {/* New line number gutter */}
+      <span
+        style={{
+          width: GUTTER_WIDTH,
+          minWidth: GUTTER_WIDTH,
+          textAlign: 'right',
+          paddingRight: 6,
+          color: colors.textMuted,
+          userSelect: 'none',
+          fontSize: 11,
+        }}
+      >
+        {line.newLineNum ?? ''}
+      </span>
+
+      {/* Prefix (+/-/space) */}
+      <span
+        style={{
+          width: '2ch',
+          minWidth: '2ch',
+          color: line.type === 'addition' ? colors.diffAddedBorder
+               : line.type === 'deletion' ? colors.diffRemovedBorder
+               : colors.textMuted,
+          userSelect: 'none',
+        }}
+      >
+        {prefix}
+      </span>
+
+      {/* Line content */}
+      <span
+        style={{
+          color: line.type === 'context' ? colors.textTertiary : colors.textPrimary,
+          whiteSpace: 'pre',
+          paddingRight: 10,
+        }}
+      >
+        {line.content}
+      </span>
+    </div>
+  )
+}

--- a/src/renderer/theme.ts
+++ b/src/renderer/theme.ts
@@ -134,6 +134,13 @@ const darkColors = {
   // Permission denied card
   permissionDeniedBorder: 'rgba(196, 112, 96, 0.3)',
   permissionDeniedHeaderBorder: 'rgba(196, 112, 96, 0.12)',
+
+  // Diff viewer
+  diffAddedBg: 'rgba(34, 197, 94, 0.12)',
+  diffAddedBorder: '#22c55e',
+  diffRemovedBg: 'rgba(239, 68, 68, 0.12)',
+  diffRemovedBorder: '#ef4444',
+  diffHunkHeader: '#76766e',
 } as const
 
 const lightColors = {
@@ -264,6 +271,13 @@ const lightColors = {
   // Permission denied card
   permissionDeniedBorder: 'rgba(196, 112, 96, 0.3)',
   permissionDeniedHeaderBorder: 'rgba(196, 112, 96, 0.12)',
+
+  // Diff viewer
+  diffAddedBg: 'rgba(34, 197, 94, 0.15)',
+  diffAddedBorder: '#16a34a',
+  diffRemovedBg: 'rgba(239, 68, 68, 0.15)',
+  diffRemovedBorder: '#dc2626',
+  diffHunkHeader: '#8a8a80',
 } as const
 
 export type ColorPalette = { [K in keyof typeof darkColors]: string }

--- a/src/renderer/utils/diff.ts
+++ b/src/renderer/utils/diff.ts
@@ -1,0 +1,164 @@
+/**
+ * Diff algorithm (LCS-based) — produces unified-style diff hunks.
+ * Pure logic, no React or DOM dependencies.
+ *
+ * Uses a standard LCS (Longest Common Subsequence) table to derive
+ * the minimal edit script, then groups edits into context-bounded hunks.
+ */
+
+export interface DiffLine {
+  type: 'addition' | 'deletion' | 'context'
+  content: string
+  oldLineNum?: number
+  newLineNum?: number
+}
+
+export interface DiffHunk {
+  oldStart: number
+  newStart: number
+  lines: DiffLine[]
+}
+
+/** Edit operation: 0 = context, -1 = deletion, 1 = addition */
+type EditOp = { op: 0 | -1 | 1; line: string }
+
+/**
+ * Compute the LCS table between two line arrays.
+ * dp[i][j] = length of LCS of a[0..i-1] and b[0..j-1]
+ */
+function lcsTable(a: string[], b: string[]): Uint16Array[] {
+  const n = a.length
+  const m = b.length
+  // dp is (n+1) x (m+1), each row is a Uint16Array for memory efficiency
+  const dp: Uint16Array[] = []
+  for (let i = 0; i <= n; i++) {
+    dp.push(new Uint16Array(m + 1))
+  }
+  for (let i = 1; i <= n; i++) {
+    for (let j = 1; j <= m; j++) {
+      if (a[i - 1] === b[j - 1]) {
+        dp[i][j] = dp[i - 1][j - 1] + 1
+      } else {
+        dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1])
+      }
+    }
+  }
+  return dp
+}
+
+/**
+ * Backtrack the LCS table to produce an edit script.
+ * Walks from dp[n][m] back to dp[0][0].
+ */
+function backtrack(dp: Uint16Array[], a: string[], b: string[]): EditOp[] {
+  const edits: EditOp[] = []
+  let i = a.length
+  let j = b.length
+
+  while (i > 0 || j > 0) {
+    if (i > 0 && j > 0 && a[i - 1] === b[j - 1]) {
+      edits.push({ op: 0, line: a[i - 1] })
+      i--
+      j--
+    } else if (j > 0 && (i === 0 || dp[i][j - 1] >= dp[i - 1][j])) {
+      edits.push({ op: 1, line: b[j - 1] })
+      j--
+    } else {
+      edits.push({ op: -1, line: a[i - 1] })
+      i--
+    }
+  }
+
+  edits.reverse()
+  return edits
+}
+
+/**
+ * Generate unified diff hunks between two strings.
+ * @param oldStr - Original text
+ * @param newStr - Modified text
+ * @param contextLines - Number of context lines around changes (default: 3)
+ * @returns Array of diff hunks; empty if strings are identical
+ */
+export function generateDiff(oldStr: string, newStr: string, contextLines = 3): DiffHunk[] {
+  if (oldStr === newStr) return []
+
+  const oldLines = oldStr === '' ? [] : oldStr.split('\n')
+  const newLines = newStr === '' ? [] : newStr.split('\n')
+
+  if (oldLines.length === 0 && newLines.length === 0) return []
+
+  const dp = lcsTable(oldLines, newLines)
+  const edits = backtrack(dp, oldLines, newLines)
+
+  // Assign line numbers
+  interface NumberedEdit { op: 0 | -1 | 1; line: string; oldNum?: number; newNum?: number }
+  const numbered: NumberedEdit[] = []
+  let oldNum = 1
+  let newNum = 1
+  for (const e of edits) {
+    if (e.op === 0) {
+      numbered.push({ ...e, oldNum, newNum })
+      oldNum++
+      newNum++
+    } else if (e.op === -1) {
+      numbered.push({ ...e, oldNum })
+      oldNum++
+    } else {
+      numbered.push({ ...e, newNum })
+      newNum++
+    }
+  }
+
+  // Find indices of all changed lines
+  const changeIndices: number[] = []
+  for (let i = 0; i < numbered.length; i++) {
+    if (numbered[i].op !== 0) changeIndices.push(i)
+  }
+
+  if (changeIndices.length === 0) return []
+
+  // Group changes into hunks with surrounding context
+  const hunks: DiffHunk[] = []
+  let hunkStart = Math.max(0, changeIndices[0] - contextLines)
+  let hunkEnd = Math.min(numbered.length - 1, changeIndices[0] + contextLines)
+
+  for (let ci = 1; ci < changeIndices.length; ci++) {
+    const nextStart = Math.max(0, changeIndices[ci] - contextLines)
+    const nextEnd = Math.min(numbered.length - 1, changeIndices[ci] + contextLines)
+
+    if (nextStart <= hunkEnd + 1) {
+      hunkEnd = nextEnd
+    } else {
+      hunks.push(buildHunk(numbered, hunkStart, hunkEnd))
+      hunkStart = nextStart
+      hunkEnd = nextEnd
+    }
+  }
+  hunks.push(buildHunk(numbered, hunkStart, hunkEnd))
+
+  return hunks
+}
+
+function buildHunk(
+  edits: Array<{ op: 0 | -1 | 1; line: string; oldNum?: number; newNum?: number }>,
+  start: number,
+  end: number,
+): DiffHunk {
+  const first = edits[start]
+  const oldStart = first.op === 1 ? (first.newNum ?? 1) : (first.oldNum ?? 1)
+  const newStart = first.op === -1 ? (first.oldNum ?? 1) : (first.newNum ?? 1)
+
+  const lines: DiffLine[] = []
+  for (let i = start; i <= end; i++) {
+    const e = edits[i]
+    lines.push({
+      type: e.op === 0 ? 'context' : e.op === -1 ? 'deletion' : 'addition',
+      content: e.line,
+      oldLineNum: e.oldNum,
+      newLineNum: e.newNum,
+    })
+  }
+
+  return { oldStart, newStart, lines }
+}

--- a/tests/unit/diff.test.ts
+++ b/tests/unit/diff.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from 'vitest'
+import { generateDiff, DiffHunk, DiffLine } from '../../src/renderer/utils/diff'
+
+/** Helper: flatten all lines from all hunks */
+function flatLines(hunks: DiffHunk[]): DiffLine[] {
+  return hunks.flatMap((h) => h.lines)
+}
+
+/** Helper: count lines by type */
+function countTypes(hunks: DiffHunk[]) {
+  const lines = flatLines(hunks)
+  return {
+    additions: lines.filter((l) => l.type === 'addition').length,
+    deletions: lines.filter((l) => l.type === 'deletion').length,
+    context: lines.filter((l) => l.type === 'context').length,
+  }
+}
+
+describe('generateDiff', () => {
+  it('returns empty array for identical strings', () => {
+    expect(generateDiff('hello\nworld', 'hello\nworld')).toEqual([])
+  })
+
+  it('returns empty array for two empty strings', () => {
+    expect(generateDiff('', '')).toEqual([])
+  })
+
+  it('handles addition only (empty old string)', () => {
+    const hunks = generateDiff('', 'line1\nline2\nline3')
+    expect(hunks.length).toBeGreaterThanOrEqual(1)
+    const counts = countTypes(hunks)
+    expect(counts.additions).toBe(3)
+    expect(counts.deletions).toBe(0)
+  })
+
+  it('handles deletion only (empty new string)', () => {
+    const hunks = generateDiff('line1\nline2\nline3', '')
+    expect(hunks.length).toBeGreaterThanOrEqual(1)
+    const counts = countTypes(hunks)
+    expect(counts.deletions).toBe(3)
+    expect(counts.additions).toBe(0)
+  })
+
+  it('handles single-line change', () => {
+    const hunks = generateDiff('hello', 'world')
+    expect(hunks.length).toBe(1)
+    const counts = countTypes(hunks)
+    expect(counts.deletions).toBe(1)
+    expect(counts.additions).toBe(1)
+    const lines = flatLines(hunks)
+    expect(lines.find((l) => l.type === 'deletion')?.content).toBe('hello')
+    expect(lines.find((l) => l.type === 'addition')?.content).toBe('world')
+  })
+
+  it('handles mixed changes with context', () => {
+    const old = 'a\nb\nc\nd\ne'
+    const neu = 'a\nb\nX\nd\ne'
+    const hunks = generateDiff(old, neu)
+    expect(hunks.length).toBe(1)
+    const lines = flatLines(hunks)
+    expect(lines.find((l) => l.type === 'deletion')?.content).toBe('c')
+    expect(lines.find((l) => l.type === 'addition')?.content).toBe('X')
+    // Should have context lines around the change
+    const contextLines = lines.filter((l) => l.type === 'context')
+    expect(contextLines.length).toBeGreaterThan(0)
+  })
+
+  it('respects contextLines parameter', () => {
+    const lines = Array.from({ length: 20 }, (_, i) => `line${i + 1}`)
+    const oldStr = lines.join('\n')
+    // Change line 10 only
+    const newLines = [...lines]
+    newLines[9] = 'CHANGED'
+    const newStr = newLines.join('\n')
+
+    const hunks0 = generateDiff(oldStr, newStr, 0)
+    const context0 = flatLines(hunks0).filter((l) => l.type === 'context')
+    expect(context0.length).toBe(0)
+
+    const hunks1 = generateDiff(oldStr, newStr, 1)
+    const context1 = flatLines(hunks1).filter((l) => l.type === 'context')
+    expect(context1.length).toBe(2) // 1 before + 1 after
+
+    const hunks3 = generateDiff(oldStr, newStr, 3)
+    const context3 = flatLines(hunks3).filter((l) => l.type === 'context')
+    expect(context3.length).toBe(6) // 3 before + 3 after
+  })
+
+  it('produces multiple hunks for distant changes', () => {
+    const lines = Array.from({ length: 20 }, (_, i) => `line${i + 1}`)
+    const oldStr = lines.join('\n')
+    // Change line 2 and line 19 (far apart)
+    const newLines = [...lines]
+    newLines[1] = 'CHANGED_A'
+    newLines[18] = 'CHANGED_B'
+    const newStr = newLines.join('\n')
+
+    const hunks = generateDiff(oldStr, newStr, 1)
+    expect(hunks.length).toBe(2)
+  })
+
+  it('merges nearby changes into a single hunk', () => {
+    const lines = Array.from({ length: 10 }, (_, i) => `line${i + 1}`)
+    const oldStr = lines.join('\n')
+    // Change lines 3 and 5 (close enough with context=3)
+    const newLines = [...lines]
+    newLines[2] = 'CHANGED_A'
+    newLines[4] = 'CHANGED_B'
+    const newStr = newLines.join('\n')
+
+    const hunks = generateDiff(oldStr, newStr, 3)
+    expect(hunks.length).toBe(1)
+  })
+
+  it('assigns correct line numbers', () => {
+    const hunks = generateDiff('a\nb\nc', 'a\nX\nc')
+    const lines = flatLines(hunks)
+
+    // The deletion of 'b' should have oldLineNum=2
+    const del = lines.find((l) => l.type === 'deletion')
+    expect(del?.oldLineNum).toBe(2)
+
+    // The addition of 'X' should have newLineNum=2
+    const add = lines.find((l) => l.type === 'addition')
+    expect(add?.newLineNum).toBe(2)
+  })
+
+  it('handles appending lines at the end', () => {
+    const hunks = generateDiff('a\nb', 'a\nb\nc\nd')
+    const counts = countTypes(hunks)
+    expect(counts.additions).toBe(2)
+    expect(counts.deletions).toBe(0)
+  })
+
+  it('handles removing lines from the end', () => {
+    const hunks = generateDiff('a\nb\nc\nd', 'a\nb')
+    const counts = countTypes(hunks)
+    expect(counts.deletions).toBe(2)
+    expect(counts.additions).toBe(0)
+  })
+
+  it('handles completely different content', () => {
+    const hunks = generateDiff('aaa\nbbb', 'xxx\nyyy\nzzz')
+    const counts = countTypes(hunks)
+    expect(counts.deletions).toBe(2)
+    expect(counts.additions).toBe(3)
+  })
+
+  it('handles single line to multi-line', () => {
+    const hunks = generateDiff('single', 'first\nsecond\nthird')
+    const counts = countTypes(hunks)
+    expect(counts.deletions).toBe(1) // 'single' removed
+    expect(counts.additions).toBe(3) // 3 lines added
+  })
+
+  it('handles multi-line to single line', () => {
+    const hunks = generateDiff('first\nsecond\nthird', 'single')
+    const counts = countTypes(hunks)
+    expect(counts.deletions).toBe(3)
+    expect(counts.additions).toBe(1)
+  })
+
+  it('preserves empty lines in content', () => {
+    const hunks = generateDiff('a\n\nb', 'a\n\nc')
+    const lines = flatLines(hunks)
+    const contextEmpty = lines.find((l) => l.type === 'context' && l.content === '')
+    expect(contextEmpty).toBeDefined()
+  })
+
+  it('default context is 3 lines', () => {
+    const lines = Array.from({ length: 20 }, (_, i) => `line${i + 1}`)
+    const oldStr = lines.join('\n')
+    const newLines = [...lines]
+    newLines[9] = 'CHANGED' // change line 10
+    const newStr = newLines.join('\n')
+
+    const hunks = generateDiff(oldStr, newStr) // default context
+    const contextCount = flatLines(hunks).filter((l) => l.type === 'context').length
+    expect(contextCount).toBe(6) // 3 before + 3 after
+  })
+})


### PR DESCRIPTION
## Summary
Closes #48

- Inline colored diff view for Edit/Write tool calls in ConversationView
- LCS-based diff algorithm (~80 lines, no external deps)
- Green additions / red deletions with line number gutters
- Large diffs (>50 lines) start collapsed
- Write tool calls shown as all-green additions
- Graceful fallback to raw output on parse failure
- Diff color tokens added to both dark/light theme palettes
- 17 diff algorithm tests, build clean

## Test plan
- [x] `npm run build` — zero errors
- [x] `npx vitest run` — all tests pass
- [ ] Manual: Edit tool calls show colored diff inline
- [ ] Manual: Write tool calls show all-green additions
- [ ] Manual: Large diffs start collapsed with expand button
- [ ] Manual: Dark/light theme colors correct