### PR TITLE
FEAT-002: Cost Dashboard / Usage History

### DIFF
--- a/src/main/cost-tracker.ts
+++ b/src/main/cost-tracker.ts
@@ -1,0 +1,143 @@
+import { existsSync, mkdirSync, appendFileSync, readFileSync, renameSync, statSync } from 'fs'
+import { join } from 'path'
+import { homedir } from 'os'
+import type { CostRecord, CostSummary } from '../shared/types'
+
+const CLUI_DIR = join(homedir(), '.clui')
+const HISTORY_FILE = join(CLUI_DIR, 'cost-history.jsonl')
+const PREV_FILE = join(CLUI_DIR, 'cost-history.prev.jsonl')
+const MAX_FILE_SIZE = 5 * 1024 * 1024 // 5MB
+
+function ensureCluiDir(): void {
+  if (!existsSync(CLUI_DIR)) {
+    mkdirSync(CLUI_DIR, { recursive: true })
+  }
+}
+
+function readRecordsFromFile(filePath: string): CostRecord[] {
+  if (!existsSync(filePath)) return []
+  try {
+    const content = readFileSync(filePath, 'utf-8')
+    const lines = content.split('\n').filter((line) => line.trim().length > 0)
+    const records: CostRecord[] = []
+    for (const line of lines) {
+      try {
+        const parsed = JSON.parse(line) as CostRecord
+        // Basic validation — must have timestamp and costUsd
+        if (typeof parsed.timestamp === 'number' && typeof parsed.costUsd === 'number') {
+          records.push(parsed)
+        }
+      } catch {
+        // Skip malformed lines
+      }
+    }
+    return records
+  } catch {
+    return []
+  }
+}
+
+function getAllRecords(): CostRecord[] {
+  const prev = readRecordsFromFile(PREV_FILE)
+  const current = readRecordsFromFile(HISTORY_FILE)
+  return [...prev, ...current]
+}
+
+function rotateIfNeeded(): void {
+  try {
+    if (!existsSync(HISTORY_FILE)) return
+    const stat = statSync(HISTORY_FILE)
+    if (stat.size >= MAX_FILE_SIZE) {
+      renameSync(HISTORY_FILE, PREV_FILE)
+    }
+  } catch {
+    // Rotation failure is non-fatal
+  }
+}
+
+function buildEmptySummary(): CostSummary {
+  return {
+    totalCostUsd: 0,
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    totalDurationMs: 0,
+    runCount: 0,
+    byModel: {},
+    byProject: {},
+    byDay: [],
+  }
+}
+
+export function appendRecord(record: CostRecord): void {
+  ensureCluiDir()
+  rotateIfNeeded()
+  const line = JSON.stringify(record) + '\n'
+  appendFileSync(HISTORY_FILE, line, 'utf-8')
+}
+
+export function getSummary(fromTimestamp?: number, toTimestamp?: number): CostSummary {
+  let records = getAllRecords()
+
+  if (fromTimestamp != null) {
+    records = records.filter((r) => r.timestamp >= fromTimestamp)
+  }
+  if (toTimestamp != null) {
+    records = records.filter((r) => r.timestamp <= toTimestamp)
+  }
+
+  if (records.length === 0) return buildEmptySummary()
+
+  const summary = buildEmptySummary()
+  const dayMap = new Map<string, { costUsd: number; runs: number }>()
+
+  for (const r of records) {
+    summary.totalCostUsd += r.costUsd
+    summary.totalInputTokens += r.inputTokens
+    summary.totalOutputTokens += r.outputTokens
+    summary.totalDurationMs += r.durationMs
+    summary.runCount += 1
+
+    // By model
+    const modelKey = r.model || 'unknown'
+    if (!summary.byModel[modelKey]) {
+      summary.byModel[modelKey] = { costUsd: 0, runs: 0 }
+    }
+    summary.byModel[modelKey].costUsd += r.costUsd
+    summary.byModel[modelKey].runs += 1
+
+    // By project
+    const projectKey = r.projectPath || 'unknown'
+    if (!summary.byProject[projectKey]) {
+      summary.byProject[projectKey] = { costUsd: 0, runs: 0 }
+    }
+    summary.byProject[projectKey].costUsd += r.costUsd
+    summary.byProject[projectKey].runs += 1
+
+    // By day
+    const date = new Date(r.timestamp).toISOString().slice(0, 10)
+    const existing = dayMap.get(date)
+    if (existing) {
+      existing.costUsd += r.costUsd
+      existing.runs += 1
+    } else {
+      dayMap.set(date, { costUsd: r.costUsd, runs: 1 })
+    }
+  }
+
+  // Sort by day ascending
+  summary.byDay = [...dayMap.entries()]
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([date, data]) => ({ date, ...data }))
+
+  return summary
+}
+
+export function getHistory(limit?: number): CostRecord[] {
+  const records = getAllRecords()
+  // Sort by timestamp descending (most recent first)
+  records.sort((a, b) => b.timestamp - a.timestamp)
+  if (limit != null && limit > 0) {
+    return records.slice(0, limit)
+  }
+  return records
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -16,8 +16,9 @@ import { SettingsManager } from './settings-manager'
 import { AgentMemory } from './agent-memory'
 import { PinnedSessionStore } from './pinned-sessions'
 import { exportSessionToFile } from './session-export'
+import { appendRecord as costAppendRecord, getSummary as costGetSummary, getHistory as costGetHistory } from './cost-tracker'
 import { IPC } from '../shared/types'
-import type { RunOptions, NormalizedEvent, EnrichedError, ExportOptions, SessionExportData } from '../shared/types'
+import type { RunOptions, NormalizedEvent, EnrichedError, ExportOptions, SessionExportData, CostRecord } from '../shared/types'
 
 const DEBUG_MODE = process.env.CLUI_DEBUG === '1'
 const SPACES_DEBUG = DEBUG_MODE || process.env.CLUI_SPACES_DEBUG === '1'
@@ -908,6 +909,23 @@ ipcMain.handle(IPC.PERMISSIONS_NEEDS_SETUP, () => {
 ipcMain.handle(IPC.PERMISSIONS_DISMISS_SETUP, () => {
   settingsManager.dismissSetup()
   return true
+})
+
+// ─── Cost Tracking IPC ───
+
+ipcMain.on(IPC.COST_RECORD, (_event, record: CostRecord) => {
+  log(`IPC COST_RECORD: session=${record.sessionId} cost=$${record.costUsd.toFixed(4)}`)
+  costAppendRecord(record)
+})
+
+ipcMain.handle(IPC.COST_SUMMARY, (_event, from?: number, to?: number) => {
+  log(`IPC COST_SUMMARY${from ? ` from=${from}` : ''}${to ? ` to=${to}` : ''}`)
+  return costGetSummary(from, to)
+})
+
+ipcMain.handle(IPC.COST_HISTORY, (_event, limit?: number) => {
+  log(`IPC COST_HISTORY${limit ? ` limit=${limit}` : ''}`)
+  return costGetHistory(limit)
 })
 
 // ─── Marketplace IPC ───

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -14,6 +14,8 @@ import type {
   ExportOptions,
   SessionExportData,
   SessionExportResult,
+  CostRecord,
+  CostSummary,
 } from '../shared/types'
 
 export interface CluiAPI {
@@ -59,6 +61,9 @@ export interface CluiAPI {
   applyPermissionPreset(preset: string): Promise<boolean>
   needsPermissionSetup(): Promise<boolean>
   dismissPermissionSetup(): Promise<boolean>
+  recordCost(record: CostRecord): void
+  getCostSummary(from?: number, to?: number): Promise<CostSummary>
+  getCostHistory(limit?: number): Promise<CostRecord[]>
   sendDesktopNotification(title: string, body: string): Promise<void>
   getTheme(): Promise<{ isDark: boolean }>
   onThemeChange(callback: (isDark: boolean) => void): () => void
@@ -128,6 +133,9 @@ const api: CluiAPI = {
   applyPermissionPreset: (preset) => ipcRenderer.invoke(IPC.PERMISSIONS_APPLY_PRESET, preset),
   needsPermissionSetup: () => ipcRenderer.invoke(IPC.PERMISSIONS_NEEDS_SETUP),
   dismissPermissionSetup: () => ipcRenderer.invoke(IPC.PERMISSIONS_DISMISS_SETUP),
+  recordCost: (record) => ipcRenderer.send(IPC.COST_RECORD, record),
+  getCostSummary: (from, to) => ipcRenderer.invoke(IPC.COST_SUMMARY, from, to),
+  getCostHistory: (limit) => ipcRenderer.invoke(IPC.COST_HISTORY, limit),
   sendDesktopNotification: (title: string, body: string) => ipcRenderer.invoke(IPC.NOTIFY_DESKTOP, title, body),
   getTheme: () => ipcRenderer.invoke(IPC.GET_THEME),
   onThemeChange: (callback) => {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -6,6 +6,7 @@ import { ConversationView } from './components/ConversationView'
 import { InputBar } from './components/InputBar'
 import { StatusBar } from './components/StatusBar'
 import { MarketplacePanel } from './components/MarketplacePanel'
+import { CostDashboard } from './components/CostDashboard'
 import { SnippetManager } from './components/SnippetManager'
 import { ExportDialog } from './components/ExportDialog'
 import { ShortcutSettings } from './components/ShortcutSettings'
@@ -181,6 +182,7 @@ export default function App() {
 
   const isExpanded = useSessionStore((s) => s.isExpanded)
   const marketplaceOpen = useSessionStore((s) => s.marketplaceOpen)
+  const costDashboardOpen = useSessionStore((s) => s.costDashboardOpen)
   const snippetManagerOpen = useSnippetStore((s) => s.managerOpen)
   const exportDialogOpen = useExportStore((s) => s.isOpen)
   const shortcutBindings = useShortcutStore((s) => s.bindings)
@@ -254,6 +256,41 @@ export default function App() {
                     }}
                   >
                     <MarketplacePanel />
+                  </div>
+                </motion.div>
+              </div>
+            )}
+          </AnimatePresence>
+
+          <AnimatePresence initial={false}>
+            {costDashboardOpen && (
+              <div
+                data-clui-ui
+                style={{
+                  width: 720,
+                  maxWidth: 720,
+                  marginLeft: '50%',
+                  transform: 'translateX(-50%)',
+                  marginBottom: 14,
+                  position: 'relative',
+                  zIndex: 30,
+                }}
+              >
+                <motion.div
+                  initial={{ opacity: 0, y: 14, scale: 0.98 }}
+                  animate={{ opacity: 1, y: 0, scale: 1 }}
+                  exit={{ opacity: 0, y: 10, scale: 0.985 }}
+                  transition={TRANSITION}
+                >
+                  <div
+                    data-clui-ui
+                    className="glass-surface overflow-hidden no-drag"
+                    style={{
+                      borderRadius: 24,
+                      maxHeight: 470,
+                    }}
+                  >
+                    <CostDashboard />
                   </div>
                 </motion.div>
               </div>

--- a/src/renderer/components/CostDashboard.tsx
+++ b/src/renderer/components/CostDashboard.tsx
@@ -1,0 +1,428 @@
+import React, { useState, useEffect, useMemo } from 'react'
+import { motion } from 'framer-motion'
+import { X, ChartBar, Clock, Coins, Lightning } from '@phosphor-icons/react'
+import { useSessionStore } from '../stores/sessionStore'
+import { useColors } from '../theme'
+import type { CostSummary } from '../../shared/types'
+
+type TimeRange = 'today' | '7d' | '30d' | 'all'
+
+function getTimestampForRange(range: TimeRange): number | undefined {
+  if (range === 'all') return undefined
+  const now = Date.now()
+  switch (range) {
+    case 'today': {
+      const d = new Date()
+      d.setHours(0, 0, 0, 0)
+      return d.getTime()
+    }
+    case '7d': return now - 7 * 24 * 60 * 60 * 1000
+    case '30d': return now - 30 * 24 * 60 * 60 * 1000
+  }
+}
+
+function formatCost(usd: number): string {
+  if (usd < 0.01) return `$${usd.toFixed(4)}`
+  if (usd < 1) return `$${usd.toFixed(3)}`
+  return `$${usd.toFixed(2)}`
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`
+  const seconds = Math.round(ms / 1000)
+  if (seconds < 60) return `${seconds}s`
+  const minutes = Math.floor(seconds / 60)
+  const remainingSeconds = seconds % 60
+  if (minutes < 60) return `${minutes}m ${remainingSeconds}s`
+  const hours = Math.floor(minutes / 60)
+  const remainingMinutes = minutes % 60
+  return `${hours}h ${remainingMinutes}m`
+}
+
+function formatTokens(count: number): string {
+  if (count < 1000) return String(count)
+  if (count < 1_000_000) return `${(count / 1000).toFixed(1)}k`
+  return `${(count / 1_000_000).toFixed(2)}M`
+}
+
+function shortenPath(path: string): string {
+  // Show last two segments of the path
+  const parts = path.replace(/\\/g, '/').split('/')
+  if (parts.length <= 2) return path
+  return parts.slice(-2).join('/')
+}
+
+const RANGE_LABELS: Record<TimeRange, string> = {
+  today: 'Today',
+  '7d': '7 Days',
+  '30d': '30 Days',
+  all: 'All Time',
+}
+
+export function CostDashboard() {
+  const colors = useColors()
+  const closeCostDashboard = useSessionStore((s) => s.closeCostDashboard)
+
+  const [range, setRange] = useState<TimeRange>('7d')
+  const [summary, setSummary] = useState<CostSummary | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    const from = getTimestampForRange(range)
+    window.clui.getCostSummary(from).then((data) => {
+      if (!cancelled) {
+        setSummary(data)
+        setLoading(false)
+      }
+    }).catch(() => {
+      if (!cancelled) setLoading(false)
+    })
+    return () => { cancelled = true }
+  }, [range])
+
+  const maxDayCost = useMemo(() => {
+    if (!summary || summary.byDay.length === 0) return 0
+    return Math.max(...summary.byDay.map((d) => d.costUsd))
+  }, [summary])
+
+  const maxModelCost = useMemo(() => {
+    if (!summary) return 0
+    const values = Object.values(summary.byModel).map((m) => m.costUsd)
+    return values.length > 0 ? Math.max(...values) : 0
+  }, [summary])
+
+  const maxProjectCost = useMemo(() => {
+    if (!summary) return 0
+    const values = Object.values(summary.byProject).map((p) => p.costUsd)
+    return values.length > 0 ? Math.max(...values) : 0
+  }, [summary])
+
+  const sortedModels = useMemo(() => {
+    if (!summary) return []
+    return Object.entries(summary.byModel)
+      .sort((a, b) => b[1].costUsd - a[1].costUsd)
+  }, [summary])
+
+  const sortedProjects = useMemo(() => {
+    if (!summary) return []
+    return Object.entries(summary.byProject)
+      .sort((a, b) => b[1].costUsd - a[1].costUsd)
+      .slice(0, 8) // Show top 8 projects
+  }, [summary])
+
+  const isEmpty = !loading && summary && summary.runCount === 0
+
+  return (
+    <div
+      data-clui-ui
+      style={{
+        height: 470,
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
+      {/* Header */}
+      <div style={{
+        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+        padding: '16px 18px 10px',
+        borderBottom: `1px solid ${colors.containerBorder}`,
+      }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <ChartBar size={20} weight="regular" style={{ color: colors.accent }} />
+          <div>
+            <div style={{ fontSize: 13, fontWeight: 700, color: colors.textPrimary }}>
+              Usage Dashboard
+            </div>
+            <div style={{ fontSize: 11, color: colors.textTertiary, marginTop: 2 }}>
+              Cost and token usage analytics
+            </div>
+          </div>
+        </div>
+        <button
+          onClick={closeCostDashboard}
+          style={{
+            background: 'none', border: 'none', cursor: 'pointer',
+            color: colors.textTertiary, padding: 2, display: 'flex',
+            borderRadius: 4,
+          }}
+          onMouseEnter={(e) => (e.currentTarget.style.color = colors.textPrimary)}
+          onMouseLeave={(e) => (e.currentTarget.style.color = colors.textTertiary)}
+        >
+          <X size={14} />
+        </button>
+      </div>
+
+      {/* Time range tabs */}
+      <div style={{
+        display: 'flex', gap: 8, padding: '12px 18px 10px',
+      }}>
+        {(Object.keys(RANGE_LABELS) as TimeRange[]).map((r) => (
+          <button
+            key={r}
+            onClick={() => setRange(r)}
+            style={{
+              fontSize: 11,
+              fontWeight: 600,
+              padding: '6px 11px',
+              borderRadius: 999,
+              border: `1px solid ${range === r ? colors.accent : colors.containerBorder}`,
+              background: range === r ? colors.accentLight : 'transparent',
+              color: range === r ? colors.accent : colors.textSecondary,
+              cursor: 'pointer',
+              fontFamily: 'inherit',
+              transition: 'all 0.15s',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {RANGE_LABELS[r]}
+          </button>
+        ))}
+      </div>
+
+      {/* Body */}
+      <div style={{ flex: 1, overflowY: 'auto', padding: '0 18px 12px', scrollbarWidth: 'thin' }}>
+        {loading ? (
+          <LoadingState colors={colors} />
+        ) : isEmpty ? (
+          <EmptyState colors={colors} />
+        ) : summary ? (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+            {/* Summary cards */}
+            <div style={{ display: 'flex', gap: 10 }}>
+              <SummaryCard
+                icon={<Coins size={14} weight="regular" />}
+                label="Total Cost"
+                value={formatCost(summary.totalCostUsd)}
+                sublabel={`${summary.runCount} run${summary.runCount === 1 ? '' : 's'}`}
+                colors={colors}
+              />
+              <SummaryCard
+                icon={<Lightning size={14} weight="regular" />}
+                label="Total Tokens"
+                value={formatTokens(summary.totalInputTokens + summary.totalOutputTokens)}
+                sublabel={`${formatTokens(summary.totalInputTokens)} in / ${formatTokens(summary.totalOutputTokens)} out`}
+                colors={colors}
+              />
+              <SummaryCard
+                icon={<Clock size={14} weight="regular" />}
+                label="Total Time"
+                value={formatDuration(summary.totalDurationMs)}
+                sublabel={summary.runCount > 0 ? `avg ${formatDuration(Math.round(summary.totalDurationMs / summary.runCount))}` : ''}
+                colors={colors}
+              />
+            </div>
+
+            {/* Daily spend chart */}
+            {summary.byDay.length > 0 && (
+              <div>
+                <div style={{ fontSize: 11, fontWeight: 600, color: colors.textPrimary, marginBottom: 8 }}>
+                  Daily Spend
+                </div>
+                <div style={{ display: 'flex', alignItems: 'flex-end', gap: 3, height: 80 }}>
+                  {summary.byDay.map((day) => {
+                    const pct = maxDayCost > 0 ? (day.costUsd / maxDayCost) * 100 : 0
+                    return (
+                      <div
+                        key={day.date}
+                        style={{
+                          flex: 1,
+                          display: 'flex',
+                          flexDirection: 'column',
+                          alignItems: 'center',
+                          gap: 4,
+                          minWidth: 0,
+                        }}
+                        title={`${day.date}: ${formatCost(day.costUsd)} (${day.runs} run${day.runs === 1 ? '' : 's'})`}
+                      >
+                        <div
+                          style={{
+                            width: '100%',
+                            maxWidth: 28,
+                            height: `${Math.max(pct, 3)}%`,
+                            borderRadius: 4,
+                            background: `linear-gradient(to top, ${colors.accent}, rgba(217, 119, 87, 0.6))`,
+                            transition: 'height 0.3s ease',
+                            minHeight: 2,
+                          }}
+                        />
+                        <div style={{
+                          fontSize: 8,
+                          color: colors.textTertiary,
+                          whiteSpace: 'nowrap',
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                          width: '100%',
+                          textAlign: 'center',
+                        }}>
+                          {day.date.slice(5)}
+                        </div>
+                      </div>
+                    )
+                  })}
+                </div>
+              </div>
+            )}
+
+            {/* By Model breakdown */}
+            {sortedModels.length > 0 && (
+              <div>
+                <div style={{ fontSize: 11, fontWeight: 600, color: colors.textPrimary, marginBottom: 8 }}>
+                  By Model
+                </div>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                  {sortedModels.map(([model, data]) => {
+                    const pct = maxModelCost > 0 ? (data.costUsd / maxModelCost) * 100 : 0
+                    return (
+                      <div key={model}>
+                        <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 3 }}>
+                          <span style={{ fontSize: 11, color: colors.textSecondary }}>{model}</span>
+                          <span style={{ fontSize: 10, color: colors.textTertiary }}>
+                            {formatCost(data.costUsd)} ({data.runs} run{data.runs === 1 ? '' : 's'})
+                          </span>
+                        </div>
+                        <div style={{
+                          height: 6,
+                          borderRadius: 3,
+                          background: colors.surfacePrimary,
+                          overflow: 'hidden',
+                        }}>
+                          <div style={{
+                            width: `${pct}%`,
+                            height: '100%',
+                            borderRadius: 3,
+                            background: colors.accent,
+                            transition: 'width 0.3s ease',
+                          }} />
+                        </div>
+                      </div>
+                    )
+                  })}
+                </div>
+              </div>
+            )}
+
+            {/* By Project breakdown */}
+            {sortedProjects.length > 0 && (
+              <div>
+                <div style={{ fontSize: 11, fontWeight: 600, color: colors.textPrimary, marginBottom: 8 }}>
+                  By Project
+                </div>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                  {sortedProjects.map(([project, data]) => {
+                    const pct = maxProjectCost > 0 ? (data.costUsd / maxProjectCost) * 100 : 0
+                    return (
+                      <div key={project}>
+                        <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 3 }}>
+                          <span style={{
+                            fontSize: 11,
+                            color: colors.textSecondary,
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
+                            maxWidth: '60%',
+                          }}>
+                            {shortenPath(project)}
+                          </span>
+                          <span style={{ fontSize: 10, color: colors.textTertiary, flexShrink: 0 }}>
+                            {formatCost(data.costUsd)} ({data.runs} run{data.runs === 1 ? '' : 's'})
+                          </span>
+                        </div>
+                        <div style={{
+                          height: 6,
+                          borderRadius: 3,
+                          background: colors.surfacePrimary,
+                          overflow: 'hidden',
+                        }}>
+                          <div style={{
+                            width: `${pct}%`,
+                            height: '100%',
+                            borderRadius: 3,
+                            background: colors.statusComplete,
+                            transition: 'width 0.3s ease',
+                          }} />
+                        </div>
+                      </div>
+                    )
+                  })}
+                </div>
+              </div>
+            )}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+// ─── Summary Card ───
+
+function SummaryCard({ icon, label, value, sublabel, colors }: {
+  icon: React.ReactNode
+  label: string
+  value: string
+  sublabel: string
+  colors: ReturnType<typeof useColors>
+}) {
+  return (
+    <div style={{
+      flex: 1,
+      padding: '10px 12px',
+      borderRadius: 12,
+      border: `1px solid ${colors.containerBorder}`,
+      background: colors.surfaceHover,
+    }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 5, marginBottom: 6 }}>
+        <span style={{ color: colors.textTertiary, display: 'flex' }}>{icon}</span>
+        <span style={{ fontSize: 10, color: colors.textTertiary, fontWeight: 500 }}>{label}</span>
+      </div>
+      <div style={{ fontSize: 16, fontWeight: 700, color: colors.textPrimary, lineHeight: 1.2 }}>
+        {value}
+      </div>
+      {sublabel && (
+        <div style={{ fontSize: 9, color: colors.textTertiary, marginTop: 3 }}>
+          {sublabel}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ─── States ───
+
+function LoadingState({ colors }: { colors: ReturnType<typeof useColors> }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 10, padding: '8px 0' }}>
+      {[0, 1, 2].map((i) => (
+        <motion.div
+          key={i}
+          animate={{ opacity: [0.3, 0.6, 0.3] }}
+          transition={{ duration: 1.5, repeat: Infinity, delay: i * 0.15 }}
+          style={{
+            height: 40,
+            borderRadius: 10,
+            background: colors.surfacePrimary,
+          }}
+        />
+      ))}
+    </div>
+  )
+}
+
+function EmptyState({ colors }: { colors: ReturnType<typeof useColors> }) {
+  return (
+    <div style={{
+      padding: '40px 10px',
+      textAlign: 'center',
+    }}>
+      <ChartBar size={32} weight="thin" style={{ color: colors.textTertiary, margin: '0 auto 12px' }} />
+      <div style={{ fontSize: 12, fontWeight: 600, color: colors.textSecondary, marginBottom: 4 }}>
+        No usage data yet
+      </div>
+      <div style={{ fontSize: 11, color: colors.textTertiary, lineHeight: 1.5 }}>
+        Cost data will appear here after your first completed task.
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/SettingsPopover.tsx
+++ b/src/renderer/components/SettingsPopover.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react'
 import { createPortal } from 'react-dom'
 import { motion } from 'framer-motion'
-import { DotsThree, Bell, BellRinging, ChatText, ArrowsOutSimple, Moon, ShieldCheck, NotePencil, Keyboard } from '@phosphor-icons/react'
+import { DotsThree, Bell, BellRinging, ChatText, ArrowsOutSimple, Moon, ShieldCheck, NotePencil, Keyboard, ChartBar } from '@phosphor-icons/react'
 import { useThemeStore } from '../theme'
 import { useSessionStore } from '../stores/sessionStore'
 import { useShortcutStore } from '../stores/shortcutStore'
@@ -346,6 +346,24 @@ export function SettingsPopover() {
                 <NotePencil size={14} style={{ color: colors.textTertiary }} />
                 <div className="text-[12px] font-medium" style={{ color: colors.textPrimary }}>
                   Snippets
+                </div>
+              </button>
+            </div>
+
+            <div style={{ height: 1, background: colors.popoverBorder }} />
+
+            <div>
+              <button
+                onClick={() => {
+                  useSessionStore.getState().toggleCostDashboard()
+                  setOpen(false)
+                }}
+                className="flex items-center gap-2 w-full text-left cursor-pointer rounded-md px-0 py-0 transition-colors"
+                style={{ background: 'transparent' }}
+              >
+                <ChartBar size={14} style={{ color: colors.textTertiary }} />
+                <div className="text-[12px] font-medium" style={{ color: colors.textPrimary }}>
+                  Usage
                 </div>
               </button>
             </div>

--- a/src/renderer/stores/sessionStore.ts
+++ b/src/renderer/stores/sessionStore.ts
@@ -59,6 +59,9 @@ interface State {
   marketplaceSearch: string
   marketplaceFilter: string
 
+  // Cost dashboard state
+  costDashboardOpen: boolean
+
   // Actions
   initStaticInfo: () => Promise<void>
   setPreferredModel: (model: string | null) => void
@@ -70,6 +73,8 @@ interface State {
   toggleExpanded: () => void
   toggleMarketplace: () => void
   closeMarketplace: () => void
+  toggleCostDashboard: () => void
+  closeCostDashboard: () => void
   loadMarketplace: (forceRefresh?: boolean) => Promise<void>
   setMarketplaceSearch: (query: string) => void
   setMarketplaceFilter: (filter: string) => void
@@ -221,6 +226,9 @@ export const useSessionStore = create<State>((set, get) => ({
   marketplaceSearch: '',
   marketplaceFilter: 'All',
 
+  // Cost dashboard
+  costDashboardOpen: false,
+
   initStaticInfo: async () => {
     try {
       const result = await window.clui.start()
@@ -283,6 +291,7 @@ export const useSessionStore = create<State>((set, get) => ({
       set((prev) => ({
         isExpanded: willExpand,
         marketplaceOpen: false,
+        costDashboardOpen: false,
         // Expanding = reading: clear unread flag
         tabs: willExpand
           ? prev.tabs.map((t) => t.id === tabId ? { ...t, hasUnread: false } : t)
@@ -294,6 +303,7 @@ export const useSessionStore = create<State>((set, get) => ({
       set((prev) => ({
         activeTabId: tabId,
         marketplaceOpen: false,
+        costDashboardOpen: false,
         tabs: prev.tabs.map((t) =>
           t.id === tabId ? { ...t, hasUnread: false } : t
         ),
@@ -308,6 +318,7 @@ export const useSessionStore = create<State>((set, get) => ({
     set((s) => ({
       isExpanded: willExpand,
       marketplaceOpen: false,
+      costDashboardOpen: false,
       // Expanding = reading: clear unread flag for the active tab
       tabs: willExpand
         ? s.tabs.map((t) => t.id === activeTabId ? { ...t, hasUnread: false } : t)
@@ -320,13 +331,26 @@ export const useSessionStore = create<State>((set, get) => ({
     if (s.marketplaceOpen) {
       set({ marketplaceOpen: false })
     } else {
-      set({ isExpanded: false, marketplaceOpen: true })
+      set({ isExpanded: false, marketplaceOpen: true, costDashboardOpen: false })
       get().loadMarketplace()
     }
   },
 
   closeMarketplace: () => {
     set({ marketplaceOpen: false })
+  },
+
+  toggleCostDashboard: () => {
+    const s = get()
+    if (s.costDashboardOpen) {
+      set({ costDashboardOpen: false })
+    } else {
+      set({ isExpanded: false, costDashboardOpen: true, marketplaceOpen: false })
+    }
+  },
+
+  closeCostDashboard: () => {
+    set({ costDashboardOpen: false })
   },
 
   loadMarketplace: async (forceRefresh) => {
@@ -416,7 +440,7 @@ export const useSessionStore = create<State>((set, get) => ({
   },
 
   buildYourOwn: () => {
-    set({ marketplaceOpen: false, isExpanded: true })
+    set({ marketplaceOpen: false, costDashboardOpen: false, isExpanded: true })
     // Small delay to let the UI transition
     setTimeout(() => {
       get().sendMessage('Help me create a new Claude Code skill')
@@ -1031,6 +1055,24 @@ export const useSessionStore = create<State>((set, get) => ({
               updated.permissionDenied = { tools: event.permissionDenials }
             } else {
               updated.permissionDenied = null
+            }
+            // Record cost to persistent history
+            try {
+              window.clui.recordCost({
+                timestamp: Date.now(),
+                sessionId: event.sessionId,
+                model: updated.sessionModel,
+                projectPath: updated.workingDirectory,
+                costUsd: event.costUsd,
+                durationMs: event.durationMs,
+                numTurns: event.numTurns,
+                inputTokens: event.usage.input_tokens ?? 0,
+                outputTokens: event.usage.output_tokens ?? 0,
+                cacheReadTokens: event.usage.cache_read_input_tokens ?? 0,
+                cacheCreationTokens: event.usage.cache_creation_input_tokens ?? 0,
+              })
+            } catch {
+              // Cost recording failure is non-fatal
             }
             // Play notification sound if window is hidden
             playNotificationIfHidden()

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -349,6 +349,33 @@ export interface SessionLoadMessage {
   timestamp: number
 }
 
+// ─── Cost Tracking ───
+
+export interface CostRecord {
+  timestamp: number
+  sessionId: string
+  model: string | null
+  projectPath: string
+  costUsd: number
+  durationMs: number
+  numTurns: number
+  inputTokens: number
+  outputTokens: number
+  cacheReadTokens: number
+  cacheCreationTokens: number
+}
+
+export interface CostSummary {
+  totalCostUsd: number
+  totalInputTokens: number
+  totalOutputTokens: number
+  totalDurationMs: number
+  runCount: number
+  byModel: Record<string, { costUsd: number; runs: number }>
+  byProject: Record<string, { costUsd: number; runs: number }>
+  byDay: Array<{ date: string; costUsd: number; runs: number }>
+}
+
 // ─── Marketplace / Plugin Types ───
 
 export type PluginStatus = 'not_installed' | 'checking' | 'installing' | 'installed' | 'failed'
@@ -447,6 +474,11 @@ export const IPC = {
   PERMISSIONS_APPLY_PRESET: 'clui:permissions-apply-preset',
   PERMISSIONS_NEEDS_SETUP: 'clui:permissions-needs-setup',
   PERMISSIONS_DISMISS_SETUP: 'clui:permissions-dismiss-setup',
+
+  // Cost tracking
+  COST_RECORD: 'clui:cost-record',
+  COST_SUMMARY: 'clui:cost-summary',
+  COST_HISTORY: 'clui:cost-history',
 
   // Notifications
   NOTIFY_DESKTOP: 'clui:notify-desktop',

--- a/tests/unit/cost-tracker.test.ts
+++ b/tests/unit/cost-tracker.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
+import { existsSync, mkdirSync, rmSync, readFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import type { CostRecord } from '../../src/shared/types'
+
+// We need to mock os.homedir() so the cost tracker writes to a temp dir instead of real ~/.clui
+const TEST_DIR = join(tmpdir(), `clui-cost-test-${Date.now()}`)
+
+vi.mock('os', async () => {
+  const actual = await vi.importActual<typeof import('os')>('os')
+  return {
+    ...actual,
+    homedir: () => TEST_DIR,
+  }
+})
+
+// Import after mocking
+const { appendRecord, getSummary, getHistory } = await import('../../src/main/cost-tracker')
+
+function makeCostRecord(overrides: Partial<CostRecord> = {}): CostRecord {
+  return {
+    timestamp: Date.now(),
+    sessionId: 'test-session-1',
+    model: 'claude-sonnet-4-6',
+    projectPath: '/home/user/project-a',
+    costUsd: 0.05,
+    durationMs: 3000,
+    numTurns: 2,
+    inputTokens: 1000,
+    outputTokens: 500,
+    cacheReadTokens: 200,
+    cacheCreationTokens: 100,
+    ...overrides,
+  }
+}
+
+describe('CostTracker', () => {
+  beforeEach(() => {
+    // Clean up test directory before each test
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true, force: true })
+    }
+  })
+
+  afterEach(() => {
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true, force: true })
+    }
+  })
+
+  it('appendRecord creates .clui dir and writes to file', () => {
+    const record = makeCostRecord()
+    appendRecord(record)
+
+    const cluiDir = join(TEST_DIR, '.clui')
+    expect(existsSync(cluiDir)).toBe(true)
+
+    const historyFile = join(cluiDir, 'cost-history.jsonl')
+    expect(existsSync(historyFile)).toBe(true)
+
+    const content = readFileSync(historyFile, 'utf-8').trim()
+    const parsed = JSON.parse(content)
+    expect(parsed.sessionId).toBe('test-session-1')
+    expect(parsed.costUsd).toBe(0.05)
+  })
+
+  it('getSummary aggregates correctly', () => {
+    appendRecord(makeCostRecord({ costUsd: 0.10, inputTokens: 1000, outputTokens: 500, durationMs: 2000 }))
+    appendRecord(makeCostRecord({ costUsd: 0.20, inputTokens: 2000, outputTokens: 1000, durationMs: 3000 }))
+    appendRecord(makeCostRecord({ costUsd: 0.05, inputTokens: 500, outputTokens: 250, durationMs: 1000 }))
+
+    const summary = getSummary()
+    expect(summary.runCount).toBe(3)
+    expect(summary.totalCostUsd).toBeCloseTo(0.35, 4)
+    expect(summary.totalInputTokens).toBe(3500)
+    expect(summary.totalOutputTokens).toBe(1750)
+    expect(summary.totalDurationMs).toBe(6000)
+  })
+
+  it('getSummary filters by time range', () => {
+    const now = Date.now()
+    const hourAgo = now - 60 * 60 * 1000
+    const dayAgo = now - 24 * 60 * 60 * 1000
+
+    appendRecord(makeCostRecord({ timestamp: dayAgo, costUsd: 0.50 }))
+    appendRecord(makeCostRecord({ timestamp: hourAgo, costUsd: 0.10 }))
+    appendRecord(makeCostRecord({ timestamp: now, costUsd: 0.05 }))
+
+    // Filter: only last 2 hours
+    const twoHoursAgo = now - 2 * 60 * 60 * 1000
+    const summary = getSummary(twoHoursAgo)
+    expect(summary.runCount).toBe(2)
+    expect(summary.totalCostUsd).toBeCloseTo(0.15, 4)
+
+    // Filter: only between hourAgo and now
+    const summaryRange = getSummary(twoHoursAgo, hourAgo)
+    expect(summaryRange.runCount).toBe(1)
+    expect(summaryRange.totalCostUsd).toBeCloseTo(0.10, 4)
+  })
+
+  it('getHistory returns latest N records', () => {
+    const now = Date.now()
+    appendRecord(makeCostRecord({ timestamp: now - 3000, sessionId: 'oldest' }))
+    appendRecord(makeCostRecord({ timestamp: now - 2000, sessionId: 'middle' }))
+    appendRecord(makeCostRecord({ timestamp: now - 1000, sessionId: 'newest' }))
+
+    const all = getHistory()
+    expect(all.length).toBe(3)
+    // Should be sorted descending (newest first)
+    expect(all[0].sessionId).toBe('newest')
+    expect(all[2].sessionId).toBe('oldest')
+
+    const limited = getHistory(2)
+    expect(limited.length).toBe(2)
+    expect(limited[0].sessionId).toBe('newest')
+    expect(limited[1].sessionId).toBe('middle')
+  })
+
+  it('byModel breakdown groups correctly', () => {
+    appendRecord(makeCostRecord({ model: 'claude-sonnet-4-6', costUsd: 0.10 }))
+    appendRecord(makeCostRecord({ model: 'claude-sonnet-4-6', costUsd: 0.05 }))
+    appendRecord(makeCostRecord({ model: 'claude-opus-4-6', costUsd: 0.30 }))
+
+    const summary = getSummary()
+    expect(Object.keys(summary.byModel)).toHaveLength(2)
+    expect(summary.byModel['claude-sonnet-4-6'].costUsd).toBeCloseTo(0.15, 4)
+    expect(summary.byModel['claude-sonnet-4-6'].runs).toBe(2)
+    expect(summary.byModel['claude-opus-4-6'].costUsd).toBeCloseTo(0.30, 4)
+    expect(summary.byModel['claude-opus-4-6'].runs).toBe(1)
+  })
+
+  it('byProject breakdown groups correctly', () => {
+    appendRecord(makeCostRecord({ projectPath: '/a', costUsd: 0.10 }))
+    appendRecord(makeCostRecord({ projectPath: '/a', costUsd: 0.05 }))
+    appendRecord(makeCostRecord({ projectPath: '/b', costUsd: 0.20 }))
+
+    const summary = getSummary()
+    expect(Object.keys(summary.byProject)).toHaveLength(2)
+    expect(summary.byProject['/a'].costUsd).toBeCloseTo(0.15, 4)
+    expect(summary.byProject['/a'].runs).toBe(2)
+    expect(summary.byProject['/b'].costUsd).toBeCloseTo(0.20, 4)
+    expect(summary.byProject['/b'].runs).toBe(1)
+  })
+
+  it('empty file returns zero summary', () => {
+    const summary = getSummary()
+    expect(summary.runCount).toBe(0)
+    expect(summary.totalCostUsd).toBe(0)
+    expect(summary.totalInputTokens).toBe(0)
+    expect(summary.totalOutputTokens).toBe(0)
+    expect(summary.totalDurationMs).toBe(0)
+    expect(Object.keys(summary.byModel)).toHaveLength(0)
+    expect(Object.keys(summary.byProject)).toHaveLength(0)
+    expect(summary.byDay).toHaveLength(0)
+  })
+
+  it('byDay groups records by date', () => {
+    // Two records on the same day, one on a different day
+    const today = new Date()
+    today.setHours(12, 0, 0, 0)
+    const yesterday = new Date(today.getTime() - 24 * 60 * 60 * 1000)
+
+    appendRecord(makeCostRecord({ timestamp: today.getTime(), costUsd: 0.10 }))
+    appendRecord(makeCostRecord({ timestamp: today.getTime() + 1000, costUsd: 0.05 }))
+    appendRecord(makeCostRecord({ timestamp: yesterday.getTime(), costUsd: 0.20 }))
+
+    const summary = getSummary()
+    expect(summary.byDay).toHaveLength(2)
+    // Sorted ascending by date
+    expect(summary.byDay[0].costUsd).toBeCloseTo(0.20, 4)
+    expect(summary.byDay[0].runs).toBe(1)
+    expect(summary.byDay[1].costUsd).toBeCloseTo(0.15, 4)
+    expect(summary.byDay[1].runs).toBe(2)
+  })
+
+  it('handles null model gracefully', () => {
+    appendRecord(makeCostRecord({ model: null, costUsd: 0.10 }))
+
+    const summary = getSummary()
+    expect(summary.byModel['unknown']).toBeDefined()
+    expect(summary.byModel['unknown'].costUsd).toBeCloseTo(0.10, 4)
+  })
+})


### PR DESCRIPTION
## Summary
- Adds persistent cost tracking via NDJSON file (`~/.clui/cost-history.jsonl`) with 5MB file rotation
- Records cost data automatically on every `task_complete` event (cost, tokens, duration, model, project)
- New CostDashboard overlay panel with time range filters (Today/7d/30d/All), summary cards, daily spend chart (CSS-only bars), by-model and by-project breakdowns
- "Usage" entry added to SettingsPopover to toggle the dashboard
- Full IPC wiring: 3 new channels (`COST_RECORD`, `COST_SUMMARY`, `COST_HISTORY`) with types, main handlers, and preload bridge

## Test plan
- [x] `npm run build` passes with zero TypeScript errors
- [x] `npx vitest run` -- all 216 tests pass (9 new cost-tracker tests)
- [ ] Open app, complete a task, verify cost data appears in dashboard
- [ ] Verify time range filters correctly filter data
- [ ] Verify empty state shows when no data exists
- [ ] Verify dashboard closes when switching tabs or opening marketplace

Closes #36

Generated with [Claude Code](https://claude.com/claude-code)