### PR TITLE
FEAT-008: Git-Aware Context Panel

### DIFF
--- a/src/main/git-context.ts
+++ b/src/main/git-context.ts
@@ -1,0 +1,107 @@
+import { execFile } from 'child_process'
+import type { GitStatus, GitFileStatus } from '../shared/types'
+
+const MAX_DIFF_BYTES = 50 * 1024 // 50 KB
+
+/**
+ * Provides git status and diff information for a working directory.
+ * Uses child_process.execFile (no shell) to prevent injection.
+ */
+export class GitContextProvider {
+  async getStatus(cwd: string): Promise<GitStatus> {
+    try {
+      const stdout = await this.exec('git', ['status', '--porcelain', '-b'], cwd)
+      return parseStatus(stdout)
+    } catch {
+      return { isRepo: false, branch: null, files: [] }
+    }
+  }
+
+  async getDiff(cwd: string, file?: string): Promise<string> {
+    try {
+      const args = ['diff']
+      if (file) {
+        args.push('--', file)
+      }
+      const stdout = await this.exec('git', args, cwd)
+      if (stdout.length > MAX_DIFF_BYTES) {
+        return stdout.slice(0, MAX_DIFF_BYTES) + '\n\n--- Diff truncated at 50 KB ---'
+      }
+      return stdout
+    } catch {
+      return ''
+    }
+  }
+
+  private exec(cmd: string, args: string[], cwd: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+      execFile(cmd, args, { cwd, maxBuffer: 1024 * 1024, timeout: 10000 }, (error, stdout) => {
+        if (error) {
+          reject(error)
+        } else {
+          resolve(stdout)
+        }
+      })
+    })
+  }
+}
+
+/**
+ * Parse `git status --porcelain -b` output.
+ *
+ * First line: `## branch...tracking`
+ * Subsequent lines: XY path (or XY old -> new for renames)
+ */
+export function parseStatus(raw: string): GitStatus {
+  const lines = raw.split('\n').filter((l) => l.length > 0)
+
+  let branch: string | null = null
+  const files: GitFileStatus[] = []
+
+  for (const line of lines) {
+    if (line.startsWith('## ')) {
+      // Branch line: "## main...origin/main" or "## HEAD (no branch)" or "## main"
+      const branchPart = line.slice(3)
+      const dotIndex = branchPart.indexOf('...')
+      branch = dotIndex >= 0 ? branchPart.slice(0, dotIndex) : branchPart
+      // Handle detached HEAD
+      if (branch === 'HEAD (no branch)') {
+        branch = 'HEAD (detached)'
+      }
+      continue
+    }
+
+    // File status lines: XY <path> or XY <old> -> <new>
+    if (line.length < 4) continue
+
+    const xy = line.slice(0, 2)
+    const pathPart = line.slice(3)
+
+    // Map porcelain XY codes to our simplified status
+    const status = mapStatus(xy)
+    if (status) {
+      // For renames, extract the new path
+      const arrowIndex = pathPart.indexOf(' -> ')
+      const filePath = arrowIndex >= 0 ? pathPart.slice(arrowIndex + 4) : pathPart
+      files.push({ status, path: filePath })
+    }
+  }
+
+  return { isRepo: true, branch, files }
+}
+
+function mapStatus(xy: string): GitFileStatus['status'] | null {
+  // XY: X = index status, Y = work-tree status
+  // We show the most relevant status
+  const x = xy[0]
+  const y = xy[1]
+
+  if (xy === '??') return '?'
+  if (x === 'R' || y === 'R') return 'R'
+  if (x === 'A' || y === 'A') return 'A'
+  if (x === 'D' || y === 'D') return 'D'
+  if (x === 'M' || y === 'M') return 'M'
+  // Catch-all for other statuses (C, U, etc.)
+  if (x !== ' ' || y !== ' ') return 'M'
+  return null
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -17,6 +17,7 @@ import { AgentMemory } from './agent-memory'
 import { PinnedSessionStore } from './pinned-sessions'
 import { exportSessionToFile } from './session-export'
 import { appendRecord as costAppendRecord, getSummary as costGetSummary, getHistory as costGetHistory } from './cost-tracker'
+import { GitContextProvider } from './git-context'
 import { IPC } from '../shared/types'
 import type { RunOptions, NormalizedEvent, EnrichedError, ExportOptions, SessionExportData, CostRecord } from '../shared/types'
 
@@ -37,6 +38,7 @@ const INTERACTIVE_PTY = process.env.CLUI_INTERACTIVE_PERMISSIONS_PTY === '1'
 
 const settingsManager = new SettingsManager()
 const pinnedSessions = new PinnedSessionStore()
+const gitContext = new GitContextProvider()
 let agentMemory: AgentMemory | null = null
 
 const controlPlane = new ControlPlane(INTERACTIVE_PTY)
@@ -909,6 +911,18 @@ ipcMain.handle(IPC.PERMISSIONS_NEEDS_SETUP, () => {
 ipcMain.handle(IPC.PERMISSIONS_DISMISS_SETUP, () => {
   settingsManager.dismissSetup()
   return true
+})
+
+// ─── Git Context IPC ───
+
+ipcMain.handle(IPC.GIT_STATUS, (_event, cwd: string) => {
+  log(`IPC GIT_STATUS: ${cwd}`)
+  return gitContext.getStatus(cwd)
+})
+
+ipcMain.handle(IPC.GIT_DIFF, (_event, cwd: string, file?: string) => {
+  log(`IPC GIT_DIFF: ${cwd}${file ? ` file=${file}` : ''}`)
+  return gitContext.getDiff(cwd, file)
 })
 
 // ─── Cost Tracking IPC ───

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -16,6 +16,7 @@ import type {
   SessionExportResult,
   CostRecord,
   CostSummary,
+  GitStatus,
 } from '../shared/types'
 
 export interface CluiAPI {
@@ -64,6 +65,8 @@ export interface CluiAPI {
   recordCost(record: CostRecord): void
   getCostSummary(from?: number, to?: number): Promise<CostSummary>
   getCostHistory(limit?: number): Promise<CostRecord[]>
+  getGitStatus(cwd: string): Promise<GitStatus>
+  getGitDiff(cwd: string, file?: string): Promise<string>
   sendDesktopNotification(title: string, body: string): Promise<void>
   getTheme(): Promise<{ isDark: boolean }>
   onThemeChange(callback: (isDark: boolean) => void): () => void
@@ -136,6 +139,8 @@ const api: CluiAPI = {
   recordCost: (record) => ipcRenderer.send(IPC.COST_RECORD, record),
   getCostSummary: (from, to) => ipcRenderer.invoke(IPC.COST_SUMMARY, from, to),
   getCostHistory: (limit) => ipcRenderer.invoke(IPC.COST_HISTORY, limit),
+  getGitStatus: (cwd) => ipcRenderer.invoke(IPC.GIT_STATUS, cwd),
+  getGitDiff: (cwd, file) => ipcRenderer.invoke(IPC.GIT_DIFF, cwd, file),
   sendDesktopNotification: (title: string, body: string) => ipcRenderer.invoke(IPC.NOTIFY_DESKTOP, title, body),
   getTheme: () => ipcRenderer.invoke(IPC.GET_THEME),
   onThemeChange: (callback) => {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -14,6 +14,7 @@ import { ExportDialog } from './components/ExportDialog'
 import { ShortcutSettings } from './components/ShortcutSettings'
 import { PermissionWizard } from './components/PermissionWizard'
 import { CommandPalette } from './components/CommandPalette'
+import { GitPanel } from './components/GitPanel'
 import { ToastContainer } from './components/ToastContainer'
 import { PopoverLayerProvider } from './components/PopoverLayer'
 import { useClaudeEvents } from './hooks/useClaudeEvents'
@@ -40,6 +41,14 @@ export default function App() {
   const setSystemTheme = useThemeStore((s) => s.setSystemTheme)
   const expandedUI = useThemeStore((s) => s.expandedUI)
   const [showPermissionWizard, setShowPermissionWizard] = useState(false)
+  const [gitPanelOpen, setGitPanelOpen] = useState(false)
+
+  // ─── Git panel toggle (from command palette) ───
+  useEffect(() => {
+    const handler = () => setGitPanelOpen((v) => !v)
+    window.addEventListener('clui-toggle-git-panel', handler)
+    return () => window.removeEventListener('clui-toggle-git-panel', handler)
+  }, [])
 
   // ─── Permission wizard check (first launch) ───
   useEffect(() => {
@@ -235,6 +244,7 @@ export default function App() {
     <PopoverLayerProvider>
       <CommandPalette />
       <ToastContainer />
+      <GitPanel open={gitPanelOpen} onClose={() => setGitPanelOpen(false)} />
       <div className="flex flex-col justify-end h-full" style={{ background: 'transparent' }}>
 
         {/* ─── 460px content column, centered. Circles overflow left. ─── */}

--- a/src/renderer/components/CommandPalette.tsx
+++ b/src/renderer/components/CommandPalette.tsx
@@ -3,7 +3,7 @@ import { createPortal } from 'react-dom'
 import { motion } from 'framer-motion'
 import {
   Plus, ClockCounterClockwise, GearSix, HeadCircuit, Lightning, DownloadSimple,
-  Browser, Cpu, Moon, Sun, ArrowsOutSimple, ArrowsInSimple, X,
+  Browser, Cpu, Moon, Sun, ArrowsOutSimple, ArrowsInSimple, X, GitBranch,
 } from '@phosphor-icons/react'
 import { usePopoverLayer } from './PopoverLayer'
 import { useColors } from '../theme'
@@ -30,6 +30,7 @@ const ICON_MAP: Record<string, React.ReactNode> = {
   ArrowsOutSimple: <ArrowsOutSimple size={ICON_SIZE} />,
   ArrowsInSimple: <ArrowsInSimple size={ICON_SIZE} />,
   X: <X size={ICON_SIZE} />,
+  GitBranch: <GitBranch size={ICON_SIZE} />,
 }
 
 function resolveIcon(name: string): React.ReactNode {
@@ -58,6 +59,8 @@ function executeCommand(command: PaletteCommand): void {
     session.toggleMarketplace()
   } else if (id === 'snippets') {
     snippets.openManager()
+  } else if (id === 'git-panel') {
+    window.dispatchEvent(new Event('clui-toggle-git-panel'))
   } else if (id === 'toggle-expanded') {
     session.toggleExpanded()
   } else if (id === 'theme-dark') {
@@ -89,6 +92,7 @@ function buildCommands(): PaletteCommand[] {
     { id: 'history', category: 'action', icon: 'ClockCounterClockwise', label: 'Open History', shortcut: shortcutMap['open-history'] },
     { id: 'marketplace', category: 'action', icon: 'HeadCircuit', label: 'Marketplace', shortcut: shortcutMap['open-marketplace'] },
     { id: 'snippets', category: 'action', icon: 'Lightning', label: 'Manage Snippets' },
+    { id: 'git-panel', category: 'action', icon: 'GitBranch', label: 'Git Context Panel' },
     {
       id: 'toggle-expanded',
       category: 'action',

--- a/src/renderer/components/GitPanel.tsx
+++ b/src/renderer/components/GitPanel.tsx
@@ -1,0 +1,510 @@
+import React, { useState, useEffect, useCallback } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+import {
+  GitBranch,
+  ArrowClockwise,
+  PencilSimple,
+  Plus,
+  Trash,
+  Question,
+  CheckCircle,
+  X,
+  CaretDown,
+  CaretRight,
+  ArrowsLeftRight,
+  SpinnerGap,
+  Warning,
+} from '@phosphor-icons/react'
+import { useColors } from '../theme'
+import { useSessionStore } from '../stores/sessionStore'
+import type { GitStatus, GitFileStatus } from '../../shared/types'
+
+const TRANSITION = { duration: 0.2, ease: [0.4, 0, 0.1, 1] as const }
+const PANEL_WIDTH = 300
+
+interface GitPanelProps {
+  open: boolean
+  onClose: () => void
+}
+
+type PanelState = 'loading' | 'not-repo' | 'clean' | 'changes' | 'error'
+
+const STATUS_ICONS: Record<GitFileStatus['status'], React.ComponentType<{ size: number; style?: React.CSSProperties }>> = {
+  M: PencilSimple,
+  A: Plus,
+  D: Trash,
+  R: ArrowsLeftRight,
+  '?': Question,
+}
+
+function statusLabel(s: GitFileStatus['status']): string {
+  switch (s) {
+    case 'M': return 'Modified'
+    case 'A': return 'Added'
+    case 'D': return 'Deleted'
+    case 'R': return 'Renamed'
+    case '?': return 'Untracked'
+  }
+}
+
+export function GitPanel({ open, onClose }: GitPanelProps) {
+  const colors = useColors()
+  const workingDirectory = useSessionStore(
+    (s) => s.tabs.find((t) => t.id === s.activeTabId)?.workingDirectory ?? '',
+  )
+
+  const [gitStatus, setGitStatus] = useState<GitStatus | null>(null)
+  const [panelState, setPanelState] = useState<PanelState>('loading')
+  const [errorMsg, setErrorMsg] = useState<string | null>(null)
+  const [expandedFile, setExpandedFile] = useState<string | null>(null)
+  const [fileDiffs, setFileDiffs] = useState<Record<string, string>>({})
+  const [loadingDiff, setLoadingDiff] = useState<string | null>(null)
+
+  const refresh = useCallback(async () => {
+    if (!workingDirectory) {
+      setPanelState('not-repo')
+      return
+    }
+
+    setPanelState('loading')
+    setErrorMsg(null)
+    setExpandedFile(null)
+    setFileDiffs({})
+
+    try {
+      const status = await window.clui.getGitStatus(workingDirectory)
+      setGitStatus(status)
+
+      if (!status.isRepo) {
+        setPanelState('not-repo')
+      } else if (status.files.length === 0) {
+        setPanelState('clean')
+      } else {
+        setPanelState('changes')
+      }
+    } catch (err: unknown) {
+      setPanelState('error')
+      setErrorMsg(err instanceof Error ? err.message : 'Failed to get git status')
+    }
+  }, [workingDirectory])
+
+  // Auto-refresh when panel opens or working directory changes
+  useEffect(() => {
+    if (open) {
+      void refresh()
+    }
+  }, [open, workingDirectory, refresh])
+
+  const handleFileClick = useCallback(async (filePath: string) => {
+    if (expandedFile === filePath) {
+      setExpandedFile(null)
+      return
+    }
+
+    setExpandedFile(filePath)
+
+    // Fetch diff if not cached
+    if (!fileDiffs[filePath]) {
+      setLoadingDiff(filePath)
+      try {
+        const diff = await window.clui.getGitDiff(workingDirectory, filePath)
+        setFileDiffs((prev) => ({ ...prev, [filePath]: diff || '(no diff available)' }))
+      } catch {
+        setFileDiffs((prev) => ({ ...prev, [filePath]: '(failed to load diff)' }))
+      } finally {
+        setLoadingDiff(null)
+      }
+    }
+  }, [expandedFile, fileDiffs, workingDirectory])
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <motion.div
+          data-clui-ui
+          initial={{ x: PANEL_WIDTH, opacity: 0 }}
+          animate={{ x: 0, opacity: 1 }}
+          exit={{ x: PANEL_WIDTH, opacity: 0 }}
+          transition={TRANSITION}
+          style={{
+            position: 'fixed',
+            top: 0,
+            right: 0,
+            bottom: 0,
+            width: PANEL_WIDTH,
+            display: 'flex',
+            flexDirection: 'column',
+            background: colors.containerBg,
+            borderLeft: `1px solid ${colors.containerBorder}`,
+            boxShadow: '-4px 0 20px rgba(0,0,0,0.15)',
+            zIndex: 40,
+            overflow: 'hidden',
+          }}
+        >
+          {/* Header */}
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+              padding: '12px 14px',
+              borderBottom: `1px solid ${colors.containerBorder}`,
+              flexShrink: 0,
+            }}
+          >
+            <GitBranch size={16} style={{ color: colors.accent, flexShrink: 0 }} />
+            <span
+              style={{
+                color: colors.textPrimary,
+                fontSize: 13,
+                fontWeight: 600,
+                flex: 1,
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              Git Context
+            </span>
+
+            {/* Branch badge */}
+            {gitStatus?.branch && (
+              <span
+                style={{
+                  fontSize: 10,
+                  color: colors.accent,
+                  background: colors.accentLight,
+                  padding: '2px 8px',
+                  borderRadius: 9999,
+                  fontWeight: 500,
+                  maxWidth: 100,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  flexShrink: 0,
+                }}
+                title={gitStatus.branch}
+              >
+                {gitStatus.branch}
+              </span>
+            )}
+
+            <button
+              onClick={refresh}
+              title="Refresh"
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                width: 26,
+                height: 26,
+                borderRadius: 6,
+                border: 'none',
+                background: 'transparent',
+                color: colors.textTertiary,
+                cursor: 'pointer',
+                flexShrink: 0,
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.background = colors.surfaceHover
+                e.currentTarget.style.color = colors.textSecondary
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.background = 'transparent'
+                e.currentTarget.style.color = colors.textTertiary
+              }}
+            >
+              <ArrowClockwise size={14} />
+            </button>
+
+            <button
+              onClick={onClose}
+              title="Close"
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                width: 26,
+                height: 26,
+                borderRadius: 6,
+                border: 'none',
+                background: 'transparent',
+                color: colors.textTertiary,
+                cursor: 'pointer',
+                flexShrink: 0,
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.background = colors.surfaceHover
+                e.currentTarget.style.color = colors.textSecondary
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.background = 'transparent'
+                e.currentTarget.style.color = colors.textTertiary
+              }}
+            >
+              <X size={14} />
+            </button>
+          </div>
+
+          {/* Body */}
+          <div
+            style={{
+              flex: 1,
+              overflowY: 'auto',
+              padding: '8px 0',
+            }}
+            className="overflow-y-auto"
+          >
+            {panelState === 'loading' && (
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 40 }}>
+                <motion.div
+                  animate={{ rotate: 360 }}
+                  transition={{ duration: 1, repeat: Infinity, ease: 'linear' }}
+                >
+                  <SpinnerGap size={24} style={{ color: colors.textTertiary }} />
+                </motion.div>
+              </div>
+            )}
+
+            {panelState === 'not-repo' && (
+              <div style={{ padding: '40px 20px', textAlign: 'center' }}>
+                <Warning size={28} style={{ color: colors.textTertiary, marginBottom: 8 }} />
+                <div style={{ color: colors.textTertiary, fontSize: 12 }}>
+                  Not a git repository
+                </div>
+                <div style={{ color: colors.textMuted, fontSize: 11, marginTop: 4 }}>
+                  Select a directory with a git repo
+                </div>
+              </div>
+            )}
+
+            {panelState === 'error' && (
+              <div style={{ padding: '40px 20px', textAlign: 'center' }}>
+                <Warning size={28} style={{ color: colors.statusError, marginBottom: 8 }} />
+                <div style={{ color: colors.statusError, fontSize: 12 }}>
+                  {errorMsg || 'An error occurred'}
+                </div>
+              </div>
+            )}
+
+            {panelState === 'clean' && (
+              <div style={{ padding: '40px 20px', textAlign: 'center' }}>
+                <CheckCircle size={28} style={{ color: colors.statusComplete, marginBottom: 8 }} />
+                <div style={{ color: colors.textTertiary, fontSize: 12 }}>
+                  Working tree clean
+                </div>
+                <div style={{ color: colors.textMuted, fontSize: 11, marginTop: 4 }}>
+                  No uncommitted changes
+                </div>
+              </div>
+            )}
+
+            {panelState === 'changes' && gitStatus && (
+              <div>
+                {/* Summary */}
+                <div
+                  style={{
+                    padding: '4px 14px 8px',
+                    fontSize: 10,
+                    color: colors.textTertiary,
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.12em',
+                    fontWeight: 500,
+                  }}
+                >
+                  {gitStatus.files.length} changed file{gitStatus.files.length !== 1 ? 's' : ''}
+                </div>
+
+                {/* File list */}
+                {gitStatus.files.map((file) => (
+                  <FileRow
+                    key={file.path}
+                    file={file}
+                    isExpanded={expandedFile === file.path}
+                    diff={fileDiffs[file.path] ?? null}
+                    isLoadingDiff={loadingDiff === file.path}
+                    onClick={() => handleFileClick(file.path)}
+                    colors={colors}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  )
+}
+
+// ─── File row ───
+
+interface FileRowProps {
+  file: GitFileStatus
+  isExpanded: boolean
+  diff: string | null
+  isLoadingDiff: boolean
+  onClick: () => void
+  colors: ReturnType<typeof useColors>
+}
+
+function FileRow({ file, isExpanded, diff, isLoadingDiff, onClick, colors }: FileRowProps) {
+  const Icon = STATUS_ICONS[file.status]
+  const fileName = file.path.split(/[/\\]/).pop() || file.path
+  const dirPath = file.path.includes('/') ? file.path.slice(0, file.path.lastIndexOf('/') + 1) : ''
+
+  const statusColor =
+    file.status === 'A' || file.status === '?' ? colors.diffAddedBorder :
+    file.status === 'D' ? colors.diffRemovedBorder :
+    file.status === 'R' ? colors.accent :
+    colors.textSecondary
+
+  return (
+    <div>
+      <button
+        onClick={onClick}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 6,
+          width: '100%',
+          padding: '6px 14px',
+          background: isExpanded ? colors.surfaceHover : 'transparent',
+          border: 'none',
+          cursor: 'pointer',
+          textAlign: 'left',
+          color: colors.textPrimary,
+          fontSize: 12,
+        }}
+        onMouseEnter={(e) => {
+          if (!isExpanded) e.currentTarget.style.background = colors.surfaceHover
+        }}
+        onMouseLeave={(e) => {
+          if (!isExpanded) e.currentTarget.style.background = 'transparent'
+        }}
+        title={`${statusLabel(file.status)}: ${file.path}`}
+      >
+        {isExpanded
+          ? <CaretDown size={10} style={{ color: colors.textTertiary, flexShrink: 0 }} />
+          : <CaretRight size={10} style={{ color: colors.textTertiary, flexShrink: 0 }} />
+        }
+        <Icon size={13} style={{ color: statusColor, flexShrink: 0 }} />
+        <span
+          style={{
+            flex: 1,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {dirPath && (
+            <span style={{ color: colors.textTertiary }}>{dirPath}</span>
+          )}
+          <span style={{ color: colors.textPrimary }}>{fileName}</span>
+        </span>
+        <span
+          style={{
+            fontSize: 9,
+            fontWeight: 600,
+            color: statusColor,
+            textTransform: 'uppercase',
+            flexShrink: 0,
+          }}
+        >
+          {file.status === '?' ? 'U' : file.status}
+        </span>
+      </button>
+
+      {/* Inline diff */}
+      <AnimatePresence initial={false}>
+        {isExpanded && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.15 }}
+            style={{ overflow: 'hidden' }}
+          >
+            <div
+              style={{
+                margin: '0 10px 6px',
+                borderRadius: 6,
+                border: `1px solid ${colors.toolBorder}`,
+                background: colors.codeBg,
+                overflow: 'hidden',
+                fontSize: 11,
+                fontFamily: 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace',
+                maxHeight: 300,
+                overflowY: 'auto',
+              }}
+            >
+              {isLoadingDiff ? (
+                <div style={{ padding: 12, textAlign: 'center' }}>
+                  <motion.div
+                    animate={{ rotate: 360 }}
+                    transition={{ duration: 1, repeat: Infinity, ease: 'linear' }}
+                    style={{ display: 'inline-block' }}
+                  >
+                    <SpinnerGap size={16} style={{ color: colors.textTertiary }} />
+                  </motion.div>
+                </div>
+              ) : diff ? (
+                <DiffContent diff={diff} colors={colors} />
+              ) : (
+                <div style={{ padding: 12, color: colors.textTertiary, fontSize: 11 }}>
+                  No diff data
+                </div>
+              )}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  )
+}
+
+// ─── Diff content (simple line-by-line coloring) ───
+
+function DiffContent({ diff, colors }: { diff: string; colors: ReturnType<typeof useColors> }) {
+  const lines = diff.split('\n')
+
+  return (
+    <div style={{ padding: '4px 0' }}>
+      {lines.map((line, i) => {
+        let bg = 'transparent'
+        let borderLeft = '3px solid transparent'
+        let textColor = colors.textTertiary
+
+        if (line.startsWith('+') && !line.startsWith('+++')) {
+          bg = colors.diffAddedBg
+          borderLeft = `3px solid ${colors.diffAddedBorder}`
+          textColor = colors.textPrimary
+        } else if (line.startsWith('-') && !line.startsWith('---')) {
+          bg = colors.diffRemovedBg
+          borderLeft = `3px solid ${colors.diffRemovedBorder}`
+          textColor = colors.textPrimary
+        } else if (line.startsWith('@@')) {
+          textColor = colors.diffHunkHeader
+        } else if (line.startsWith('diff ') || line.startsWith('index ') || line.startsWith('---') || line.startsWith('+++')) {
+          textColor = colors.textMuted
+        }
+
+        return (
+          <div
+            key={i}
+            style={{
+              background: bg,
+              borderLeft,
+              padding: '0 8px',
+              lineHeight: '18px',
+              whiteSpace: 'pre',
+              color: textColor,
+              minHeight: 18,
+            }}
+          >
+            {line}
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -395,6 +395,19 @@ export interface CatalogPlugin {
   isSkillMd: boolean      // true = individual SKILL.md (direct install), false = CLI plugin (bundle install)
 }
 
+// ─── Git Context ───
+
+export interface GitFileStatus {
+  status: 'M' | 'A' | 'D' | 'R' | '?'
+  path: string
+}
+
+export interface GitStatus {
+  branch: string | null
+  isRepo: boolean
+  files: GitFileStatus[]
+}
+
 // ─── IPC Channel Names ───
 
 export const IPC = {
@@ -479,6 +492,10 @@ export const IPC = {
   COST_RECORD: 'clui:cost-record',
   COST_SUMMARY: 'clui:cost-summary',
   COST_HISTORY: 'clui:cost-history',
+
+  // Git context
+  GIT_STATUS: 'clui:git-status',
+  GIT_DIFF: 'clui:git-diff',
 
   // Notifications
   NOTIFY_DESKTOP: 'clui:notify-desktop',

--- a/tests/unit/git-context.test.ts
+++ b/tests/unit/git-context.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from 'vitest'
+import { parseStatus } from '../../src/main/git-context'
+
+describe('GitContextProvider.parseStatus', () => {
+  it('handles a clean repo with only branch line', () => {
+    const result = parseStatus('## main...origin/main\n')
+    expect(result.isRepo).toBe(true)
+    expect(result.branch).toBe('main')
+    expect(result.files).toEqual([])
+  })
+
+  it('handles a branch with no tracking info', () => {
+    const result = parseStatus('## feature-branch\n')
+    expect(result.isRepo).toBe(true)
+    expect(result.branch).toBe('feature-branch')
+    expect(result.files).toEqual([])
+  })
+
+  it('extracts branch name from tracking info', () => {
+    const result = parseStatus('## develop...origin/develop [ahead 2]\n')
+    expect(result.branch).toBe('develop')
+  })
+
+  it('handles detached HEAD', () => {
+    const result = parseStatus('## HEAD (no branch)\n')
+    expect(result.branch).toBe('HEAD (detached)')
+  })
+
+  it('parses modified files', () => {
+    const raw = [
+      '## main',
+      ' M src/index.ts',
+      'M  src/app.ts',
+    ].join('\n')
+
+    const result = parseStatus(raw)
+    expect(result.isRepo).toBe(true)
+    expect(result.files).toHaveLength(2)
+    expect(result.files[0]).toEqual({ status: 'M', path: 'src/index.ts' })
+    expect(result.files[1]).toEqual({ status: 'M', path: 'src/app.ts' })
+  })
+
+  it('parses added files', () => {
+    const raw = [
+      '## main',
+      'A  new-file.ts',
+    ].join('\n')
+
+    const result = parseStatus(raw)
+    expect(result.files).toHaveLength(1)
+    expect(result.files[0]).toEqual({ status: 'A', path: 'new-file.ts' })
+  })
+
+  it('parses deleted files', () => {
+    const raw = [
+      '## main',
+      ' D removed.ts',
+    ].join('\n')
+
+    const result = parseStatus(raw)
+    expect(result.files).toHaveLength(1)
+    expect(result.files[0]).toEqual({ status: 'D', path: 'removed.ts' })
+  })
+
+  it('parses untracked files', () => {
+    const raw = [
+      '## main',
+      '?? untracked.txt',
+      '?? src/new/',
+    ].join('\n')
+
+    const result = parseStatus(raw)
+    expect(result.files).toHaveLength(2)
+    expect(result.files[0]).toEqual({ status: '?', path: 'untracked.txt' })
+    expect(result.files[1]).toEqual({ status: '?', path: 'src/new/' })
+  })
+
+  it('parses renamed files (extracts new path)', () => {
+    const raw = [
+      '## main',
+      'R  old.ts -> new.ts',
+    ].join('\n')
+
+    const result = parseStatus(raw)
+    expect(result.files).toHaveLength(1)
+    expect(result.files[0]).toEqual({ status: 'R', path: 'new.ts' })
+  })
+
+  it('parses a mix of statuses', () => {
+    const raw = [
+      '## feature...origin/feature',
+      ' M src/modified.ts',
+      'A  src/added.ts',
+      ' D src/deleted.ts',
+      '?? src/untracked.ts',
+      'R  old-name.ts -> new-name.ts',
+    ].join('\n')
+
+    const result = parseStatus(raw)
+    expect(result.isRepo).toBe(true)
+    expect(result.branch).toBe('feature')
+    expect(result.files).toHaveLength(5)
+    expect(result.files.map((f) => f.status)).toEqual(['M', 'A', 'D', '?', 'R'])
+  })
+
+  it('returns isRepo: true for empty status output (no files, no branch line)', () => {
+    // This should not happen in practice, but handle gracefully
+    const result = parseStatus('')
+    expect(result.isRepo).toBe(true)
+    expect(result.branch).toBe(null)
+    expect(result.files).toEqual([])
+  })
+
+  it('handles files with spaces in paths', () => {
+    const raw = [
+      '## main',
+      ' M src/my file.ts',
+    ].join('\n')
+
+    const result = parseStatus(raw)
+    expect(result.files).toHaveLength(1)
+    expect(result.files[0].path).toBe('src/my file.ts')
+  })
+})
+
+describe('GitContextProvider diff truncation', () => {
+  it('truncates diff output beyond 50KB', async () => {
+    // This tests the truncation logic conceptually.
+    // The actual GitContextProvider.getDiff method truncates at 50KB.
+    const MAX_DIFF_BYTES = 50 * 1024
+    const longDiff = 'a'.repeat(MAX_DIFF_BYTES + 1000)
+
+    // Simulate truncation logic
+    const truncated = longDiff.length > MAX_DIFF_BYTES
+      ? longDiff.slice(0, MAX_DIFF_BYTES) + '\n\n--- Diff truncated at 50 KB ---'
+      : longDiff
+
+    expect(truncated.length).toBeLessThan(longDiff.length)
+    expect(truncated).toContain('--- Diff truncated at 50 KB ---')
+  })
+
+  it('does not truncate diff under 50KB', () => {
+    const MAX_DIFF_BYTES = 50 * 1024
+    const shortDiff = 'a'.repeat(100)
+
+    const result = shortDiff.length > MAX_DIFF_BYTES
+      ? shortDiff.slice(0, MAX_DIFF_BYTES) + '\n\n--- Diff truncated at 50 KB ---'
+      : shortDiff
+
+    expect(result).toBe(shortDiff)
+    expect(result).not.toContain('truncated')
+  })
+})


### PR DESCRIPTION
## Summary
- Adds a slide-in git context panel (300px, right side) showing branch, changed files, and inline diffs
- Wires `git status --porcelain -b` and `git diff` via `execFile` (no shell injection) through IPC to renderer
- Accessible via Command Palette ("Git Context Panel" command)
- Diff viewer uses existing diff color tokens (diffAddedBg, diffRemovedBg, etc.)
- Handles non-repo directories, clean trees, loading states, and truncates diffs at 50KB

Closes #42

## Test plan
- [x] `npm run build` passes with zero errors
- [x] `npx vitest run` passes (241 tests, including new git-context tests)
- [ ] Open overlay in a git repo directory, open command palette, select "Git Context Panel"
- [ ] Verify branch name displayed in header badge
- [ ] Click a changed file to see inline diff expand with add/remove line coloring
- [ ] Open in a non-git directory and verify "Not a git repository" state
- [ ] Verify refresh button re-fetches status
- [ ] Verify close button (X) dismisses panel