### PR TITLE
DOCS-001: Update all documentation to reflect current feature set

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,11 +13,13 @@ Clui CC is an Electron desktop overlay that wraps the Claude Code CLI (`claude -
 | Install deps | `npm install` |
 | Dev mode (hot-reload renderer) | `npm run dev` |
 | Type-check + build | `npm run build` |
+| Run tests | `npm run test` |
+| Tests in watch mode | `npm run test:watch` |
 | Environment diagnostics | `npm run doctor` |
 | Debug logging | `CLUI_DEBUG=1 npm run dev` (writes `~/.clui-debug.log`) |
 | Toggle overlay | `Alt+Space` (macOS) / `Ctrl+Space` (Windows) |
 
-There is no test suite or linter configured. `npm run build` (TypeScript strict mode) is the only verification gate. Main process changes require full restart; renderer changes hot-reload.
+Tests use [Vitest](https://vitest.dev/). `npm run build` (TypeScript strict mode) and `npm run test` must both pass. Main process changes require full restart; renderer changes hot-reload.
 
 ## Architecture (3-Layer)
 
@@ -51,7 +53,23 @@ InputBar → window.clui.prompt(tabId, requestId, opts)
 | Raw NDJSON → canonical events | `src/main/claude/event-normalizer.ts` |
 | Permission hook HTTP server | `src/main/hooks/permission-server.ts` |
 | All types & IPC channel names | `src/shared/types.ts` |
-| Zustand state store | `src/renderer/stores/sessionStore.ts` |
+| Session state store | `src/renderer/stores/sessionStore.ts` |
+| Notification store (toasts) | `src/renderer/stores/notificationStore.ts` |
+| Command palette store | `src/renderer/stores/commandPaletteStore.ts` |
+| Comparison store (multi-model) | `src/renderer/stores/comparisonStore.ts` |
+| Workflow store | `src/renderer/stores/workflowStore.ts` |
+| Tab group store | `src/renderer/stores/tabGroupStore.ts` |
+| Snippet store | `src/renderer/stores/snippetStore.ts` |
+| Shortcut store | `src/renderer/stores/shortcutStore.ts` |
+| Export store | `src/renderer/stores/exportStore.ts` |
+| Tab ordering | `src/renderer/stores/tabOrder.ts` |
+| Cost tracking | `src/main/cost-tracker.ts` |
+| Git context | `src/main/git-context.ts` |
+| Auto-attach config | `src/main/auto-attach.ts` |
+| Diff algorithm | `src/renderer/utils/diff.ts` |
+| Keyboard shortcuts | `src/shared/keyboard-shortcuts.ts` |
+| Session export logic | `src/shared/session-export.ts` |
+| Command palette definitions | `src/shared/command-palette.ts` |
 | Theme / color system | `src/renderer/theme.ts` |
 | Window creation & IPC handlers | `src/main/index.ts` |
 | Typed IPC bridge | `src/preload/index.ts` |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,15 +4,21 @@ Thanks for your interest in contributing! Clui CC is a desktop overlay for Claud
 
 ## Getting Started
 
-1. Make sure you have the [prerequisites](README.md#prerequisites) installed (macOS, Xcode CLT, Node.js 18+, Claude Code CLI 2.1+)
+1. Make sure you have the [prerequisites](README.md#prerequisites) installed:
+   - **macOS 13+** or **Windows 10+**
+   - Node.js 18+
+   - Claude Code CLI 2.1+
+   - macOS: Xcode Command Line Tools
+   - Windows: Visual Studio Build Tools (for native modules)
 2. Fork and clone the repo:
    ```bash
-   git clone https://github.com/<your-username>/clui-cc.git
-   cd clui-cc
+   git clone https://github.com/<your-username>/clui-cc-windows.git
+   cd clui-cc-windows
    ```
 3. Check your environment (optional but recommended):
    ```bash
-   npm run doctor
+   npm run doctor        # macOS
+   npm run doctor:win    # Windows
    ```
 4. Install dependencies:
    ```bash
@@ -24,9 +30,10 @@ Thanks for your interest in contributing! Clui CC is a desktop overlay for Claud
    npm run dev
    ```
 6. Make your changes in `src/`
-7. Verify your changes build cleanly:
+7. Verify your changes build and test cleanly:
    ```bash
    npm run build
+   npm run test
    ```
 
 ## Development Tips
@@ -34,7 +41,7 @@ Thanks for your interest in contributing! Clui CC is a desktop overlay for Claud
 - **Main process** changes (`src/main/`) require a full restart (`Ctrl+C` then `npm run dev`).
 - **Renderer** changes (`src/renderer/`) hot-reload automatically.
 - Set `CLUI_DEBUG=1` to enable verbose main-process logging to `~/.clui-debug.log`.
-- The app creates a transparent, click-through window. Use `Alt+Space` to toggle visibility.
+- Toggle the overlay with `Alt+Space` (macOS) or `Ctrl+Space` (Windows).
 
 ## Code Style
 
@@ -43,17 +50,23 @@ Thanks for your interest in contributing! Clui CC is a desktop overlay for Claud
 - Zustand selectors should be narrow and use custom equality functions for performance.
 - Prefer editing existing files over creating new ones.
 
-## Pull Requests
+## Branch Workflow
 
-1. Create a feature branch from `main`.
+1. Create a feature branch from `main` (e.g., `FEAT-XXX/short-description`).
 2. Keep PRs focused — one concern per PR.
 3. Include a brief description of what changed and why.
-4. Ensure `npm run build` passes with zero errors.
+4. Ensure `npm run build` and `npm run test` pass with zero errors.
+5. Push and create a PR. Enable auto-merge if CI is configured:
+   ```bash
+   git push -u origin FEAT-XXX/short-description
+   gh pr create --title "FEAT-XXX: <title>" --body "Closes #N"
+   gh pr merge <N> --auto --merge --delete-branch
+   ```
 
 ## Reporting Bugs
 
 Open an issue with:
-- macOS version
+- **OS version**: macOS version or Windows version (build number)
 - Node.js version (`node --version`)
 - Claude Code CLI version (`claude --version`)
 - Steps to reproduce

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -5,7 +5,7 @@
 
 ## What This Project Is
 
-Clui CC is an **Electron desktop overlay** (macOS production, Windows beta) that wraps the Claude Code CLI (`claude -p --output-format stream-json`) in a floating pill UI. It is NOT a web app, NOT a VS Code extension, and does NOT call the Anthropic API directly — it spawns CLI subprocesses.
+Clui CC is an **Electron desktop overlay** (macOS + Windows) that wraps the Claude Code CLI (`claude -p --output-format stream-json`) in a floating pill UI. It is NOT a web app, NOT a VS Code extension, and does NOT call the Anthropic API directly — it spawns CLI subprocesses.
 
 ## Quick Reference
 
@@ -14,7 +14,9 @@ Clui CC is an **Electron desktop overlay** (macOS production, Windows beta) that
 | Install deps | `npm install` |
 | Dev mode (hot-reload) | `npm run dev` |
 | Type-check / build | `npm run build` |
-| Toggle overlay | `Alt+Space` |
+| Run tests | `npm run test` |
+| Tests in watch mode | `npm run test:watch` |
+| Toggle overlay | `Alt+Space` (macOS) / `Ctrl+Space` (Windows) |
 | Debug logging | `CLUI_DEBUG=1 npm run dev` (writes to `~/.clui-debug.log`) |
 
 **Main process changes require full restart.** Renderer changes hot-reload.
@@ -22,7 +24,7 @@ Clui CC is an **Electron desktop overlay** (macOS production, Windows beta) that
 ## Architecture (3-Layer)
 
 ```
-Renderer (React 19 + Zustand 5 + Tailwind CSS 4)
+Renderer (React 19 + Zustand 5 + Tailwind CSS 4 + Framer Motion)
     ↕  contextBridge IPC (src/preload/index.ts)
 Main Process (Node.js / Electron 33)
     ↕  spawns subprocess
@@ -35,7 +37,7 @@ Claude Code CLI (claude -p --output-format stream-json)
 |-------|-----------|---------|
 | **Renderer** | `src/renderer/` | UI state, theming, user input, message display |
 | **Preload** | `src/preload/` | Typed IPC bridge (`window.clui` API). Security boundary. |
-| **Main** | `src/main/` | Process lifecycle, tab state machine, permission server, marketplace |
+| **Main** | `src/main/` | Process lifecycle, tab state machine, permission server, marketplace, cost tracking, git context, auto-attach |
 
 ### Key Files by Concern
 
@@ -46,7 +48,23 @@ Claude Code CLI (claude -p --output-format stream-json)
 | Raw NDJSON → canonical events | `src/main/claude/event-normalizer.ts` |
 | Permission hook server | `src/main/hooks/permission-server.ts` |
 | All TypeScript types & IPC channels | `src/shared/types.ts` |
-| Zustand state store | `src/renderer/stores/sessionStore.ts` |
+| Session state store | `src/renderer/stores/sessionStore.ts` |
+| Notification store (toasts) | `src/renderer/stores/notificationStore.ts` |
+| Command palette store | `src/renderer/stores/commandPaletteStore.ts` |
+| Comparison store (multi-model) | `src/renderer/stores/comparisonStore.ts` |
+| Workflow store | `src/renderer/stores/workflowStore.ts` |
+| Tab group store | `src/renderer/stores/tabGroupStore.ts` |
+| Snippet store | `src/renderer/stores/snippetStore.ts` |
+| Shortcut store | `src/renderer/stores/shortcutStore.ts` |
+| Export store | `src/renderer/stores/exportStore.ts` |
+| Tab ordering | `src/renderer/stores/tabOrder.ts` |
+| Cost tracking | `src/main/cost-tracker.ts` |
+| Git context | `src/main/git-context.ts` |
+| Auto-attach config | `src/main/auto-attach.ts` |
+| Diff algorithm | `src/renderer/utils/diff.ts` |
+| Keyboard shortcuts | `src/shared/keyboard-shortcuts.ts` |
+| Session export logic | `src/shared/session-export.ts` |
+| Command palette definitions | `src/shared/command-palette.ts` |
 | Theme / color system | `src/renderer/theme.ts` |
 | Main window & IPC handler setup | `src/main/index.ts` |
 | Marketplace catalog | `src/main/marketplace/catalog.ts` |
@@ -76,18 +94,40 @@ All IPC and event types live in `src/shared/types.ts`. Key types:
 - **`IPC`** — const object with all IPC channel names (use these, never raw strings)
 - **`RunOptions`** — options passed when spawning a Claude CLI run
 - **`CatalogPlugin`** — marketplace plugin metadata
+- **`CostRecord`** — per-run cost/token data
+- **`CostSummary`** — aggregated cost breakdown by model, project, day
+- **`GitStatus`** — repository branch + file status
+- **`GitFileStatus`** — individual file change status (`M`/`A`/`D`/`R`/`?`)
+- **`TabGroup`** — tab group with name, color, collapse state
+- **`AutoAttachConfig`** — project-scoped context files for auto-attachment
+- **`ExportOptions`** / **`SessionExportData`** — session export configuration and output
+- **`ShortcutBinding`** / **`ShortcutMap`** — keyboard shortcut customization
+- **`AgentAssignment`** / **`AgentMemorySnapshot`** — multi-agent work coordination
+
+Additional types in dedicated shared modules:
+
+- **`PaletteCommand`** — `src/shared/command-palette.ts`
+- **`ShortcutActionId`** / **`ShortcutConflict`** — `src/shared/keyboard-shortcuts.ts`
+
+Renderer-only types (in store files):
+
+- **`ComparisonGroup`** — `src/renderer/stores/comparisonStore.ts`
+- **`Workflow`** / **`WorkflowStep`** / **`WorkflowExecution`** — `src/renderer/stores/workflowStore.ts`
+- **`Snippet`** — `src/renderer/stores/snippetStore.ts`
+- **`Toast`** — `src/renderer/stores/notificationStore.ts`
 
 ## Conventions & Rules
 
 ### Must Follow
 
 1. **TypeScript strict mode** — zero errors required (`npm run build` must pass)
-2. **Use `IPC.*` constants** for all IPC channel names — never hardcode strings
-3. **Use `useColors()` hook** for all color references in renderer — never hardcode colors
-4. **Narrow Zustand selectors** with custom equality functions for performance
-5. **All new IPC channels** must be added to `src/shared/types.ts` AND wired in both `src/preload/index.ts` and `src/main/index.ts`
-6. **Tab state transitions** go through `ControlPlane` only — never mutate tab state directly
-7. **Always persist the Claude session ID** — whenever a session is created or resumed, save the session ID to a durable location (e.g., a file in `~/.claude/` or app config) so it can be recovered if the app or process crashes. Never rely solely on in-memory state for session tracking. If the session crashes, it must be resumable via `claude --resume <session-id>` without manual lookup.
+2. **Tests must pass** — `npm run test` must pass with zero failures
+3. **Use `IPC.*` constants** for all IPC channel names — never hardcode strings
+4. **Use `useColors()` hook** for all color references in renderer — never hardcode colors
+5. **Narrow Zustand selectors** with custom equality functions for performance
+6. **All new IPC channels** must be added to `src/shared/types.ts` AND wired in both `src/preload/index.ts` and `src/main/index.ts`
+7. **Tab state transitions** go through `ControlPlane` only — never mutate tab state directly
+8. **Always persist the Claude session ID** — whenever a session is created or resumed, save the session ID to a durable location (e.g., a file in `~/.claude/` or app config) so it can be recovered if the app or process crashes. Never rely solely on in-memory state for session tracking. If the session crashes, it must be resumable via `claude --resume <session-id>` without manual lookup.
 
 ### Security — Do Not Break
 
@@ -142,6 +182,7 @@ All IPC and event types live in `src/shared/types.ts`. Key types:
 | Animation | Framer Motion | 12 |
 | Icons | Phosphor Icons | 2 |
 | Markdown | react-markdown + remark-gfm | 9 / 4 |
+| Testing | Vitest | 4 |
 | PTY (legacy) | node-pty | 1.1 |
 
 ## Network Surface
@@ -156,7 +197,7 @@ No telemetry. No analytics. No auto-update.
 
 ## Development Workflow — Mandatory for All Issues
 
-Every issue (bug fix, feature, refactor) MUST follow this workflow strictly:
+Every issue (bug fix, feature, refactor) MUST follow this workflow strictly.
 
 This applies to any coding agent, in any client, using any LLM.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-CLUI is an Electron desktop application that provides a graphical interface for Claude Code CLI. It spawns `claude -p` subprocesses, parses their NDJSON output, and presents conversations in a floating overlay window.
+CLUI is an Electron desktop application (macOS + Windows) that provides a graphical interface for Claude Code CLI. It spawns `claude -p` subprocesses, parses their NDJSON output, and presents conversations in a floating overlay window.
 
 ```
 ┌──────────────────────────────────────────────────────────────┐
@@ -13,12 +13,24 @@ CLUI is an Electron desktop application that provides a graphical interface for 
 │  │ TabStrip  │ │Conversation  │ │ InputBar │ │ Marketplace│  │
 │  │          │ │   View       │ │          │ │   Panel    │  │
 │  └──────────┘ └──────────────┘ └──────────┘ └────────────┘  │
+│  ┌────────────┐ ┌────────────┐ ┌───────────┐ ┌───────────┐  │
+│  │ Command    │ │ Cost       │ │ DiffViewer│ │ Git Panel │  │
+│  │ Palette    │ │ Dashboard  │ │           │ │           │  │
+│  └────────────┘ └────────────┘ └───────────┘ └───────────┘  │
+│  ┌────────────┐ ┌────────────┐ ┌───────────┐ ┌───────────┐  │
+│  │ Comparison │ │ Snippet    │ │ Shortcut  │ │  Toast    │  │
+│  │ View       │ │ Manager    │ │ Settings  │ │ Container │  │
+│  └────────────┘ └────────────┘ └───────────┘ └───────────┘  │
+│  ┌────────────┐ ┌────────────┐ ┌───────────┐               │
+│  │ Workflow   │ │ TabGroup   │ │ TabContext│               │
+│  │ Manager    │ │ Header     │ │ Menu      │               │
+│  └────────────┘ └────────────┘ └───────────┘               │
 │                         │                                    │
-│                    sessionStore (Zustand)                     │
+│          Multi-store architecture (Zustand)                  │
 │                         │                                    │
-│              window.clui (preload bridge)                     │
+│              window.clui (preload bridge)                    │
 ├──────────────────────────────────────────────────────────────┤
-│                     Preload Script                            │
+│                     Preload Script                           │
 │  Typed IPC bridge — contextBridge.exposeInMainWorld          │
 ├──────────────────────────────────────────────────────────────┤
 │                     Main Process                             │
@@ -40,6 +52,18 @@ CLUI is an Electron desktop application that provides a graphical interface for 
 │  │ HTTP hooks on      │  │ GitHub raw fetch + cache   │      │
 │  │ 127.0.0.1:19836    │  │ TTL: 5 minutes             │      │
 │  └────────────────────┘  └────────────────────────────┘      │
+│                                                              │
+│  ┌────────────────────┐  ┌────────────────────────────┐      │
+│  │ CostTracker        │  │ GitContext                 │      │
+│  │ Per-run cost/token  │  │ Git status + diff for     │      │
+│  │ recording + summary │  │ working directory          │      │
+│  └────────────────────┘  └────────────────────────────┘      │
+│                                                              │
+│  ┌────────────────────┐                                      │
+│  │ AutoAttach         │                                      │
+│  │ Project-scoped     │                                      │
+│  │ context files      │                                      │
+│  └────────────────────┘                                      │
 └──────────────────────────────────────────────────────────────┘
          │                              │
     claude -p (NDJSON)          raw.githubusercontent.com
@@ -101,6 +125,29 @@ HTTP server that intercepts Claude Code tool calls via PreToolUse hooks:
 
 Security: per-launch app secret, per-run tokens, sensitive field masking, 5-minute auto-deny timeout.
 
+### CostTracker (`cost-tracker.ts`)
+
+Records per-run cost and token usage data. Provides:
+
+- `recordRun()` — persists a `CostRecord` after each task completion.
+- `getSummary()` — returns aggregated `CostSummary` with breakdowns by model, project, and day.
+- `getHistory()` — returns raw cost records for display in the Cost Dashboard.
+
+### GitContext (`git-context.ts`)
+
+Provides git repository awareness for the active working directory:
+
+- `getStatus()` — returns branch name, repo detection, and file-level status (`M`/`A`/`D`/`R`/`?`).
+- `getDiff()` — returns diff output for the working directory.
+
+### AutoAttach (`auto-attach.ts`)
+
+Manages project-scoped context files that are automatically attached to prompts:
+
+- `getConfig()` — reads auto-attach configuration for a project path.
+- `setConfig()` / `addFile()` / `removeFile()` — CRUD operations on the file list.
+- `resolveFiles()` — resolves relative paths to absolute paths for attachment.
+
 ### Marketplace Catalog (`marketplace/catalog.ts`)
 
 Fetches plugin metadata from three Anthropic GitHub repos:
@@ -124,11 +171,20 @@ All methods map to `ipcRenderer.invoke()` (request-response) or `ipcRenderer.sen
 
 ### State Management
 
-Single Zustand store (`stores/sessionStore.ts`) holds all application state:
-- Tab list with full `TabState` objects (messages, status, attachments, permissions, etc.)
-- Active tab selection
-- Marketplace state (catalog, search, filter, install progress)
-- UI state (expanded, marketplace open)
+Multi-store Zustand architecture. Each store manages a focused domain:
+
+| Store | File | Manages |
+|-------|------|---------|
+| Session store | `stores/sessionStore.ts` | Tabs, messages, tab status, marketplace state, UI state |
+| Command palette store | `stores/commandPaletteStore.ts` | Palette visibility, search, command selection |
+| Comparison store | `stores/comparisonStore.ts` | Multi-model comparison groups and results |
+| Workflow store | `stores/workflowStore.ts` | Workflow definitions, step execution, progress |
+| Tab group store | `stores/tabGroupStore.ts` | Tab group CRUD, collapse state, ordering |
+| Notification store | `stores/notificationStore.ts` | Toast queue, notification preferences |
+| Snippet store | `stores/snippetStore.ts` | User-defined prompt snippets (CRUD) |
+| Shortcut store | `stores/shortcutStore.ts` | Keyboard shortcut bindings and customization |
+| Export store | `stores/exportStore.ts` | Session export dialog state and options |
+| Tab order | `stores/tabOrder.ts` | Persistent tab ordering (localStorage) |
 
 ### Theme System (`theme.ts`)
 
@@ -138,10 +194,39 @@ Theme mode state machine: `system | light | dark` with separate `_systemIsDark` 
 
 ### Key Components
 
-- **TabStrip** — tab bar with new tab, history picker, settings popover.
-- **ConversationView** — scrollable message timeline with markdown rendering (react-markdown + remark-gfm), tool call cards, permission cards.
-- **InputBar** — prompt input with attachment chips, voice recording, slash command menu, model picker.
-- **MarketplacePanel** — plugin browser with search, semantic tag filters, install confirmation.
+| Component | File | Description |
+|-----------|------|-------------|
+| TabStrip | `TabStrip.tsx` | Tab bar with new tab, history picker, settings popover |
+| TabGroupHeader | `TabGroupHeader.tsx` | Collapsible header for tab groups |
+| TabContextMenu | `TabContextMenu.tsx` | Right-click context menu for tabs (group, close, rename) |
+| ConversationView | `ConversationView.tsx` | Scrollable message timeline with markdown rendering, tool call cards, permission cards |
+| InputBar | `InputBar.tsx` | Prompt input with attachment chips, voice recording, slash command menu |
+| CommandPalette | `CommandPalette.tsx` | Fuzzy-searchable command launcher (`Ctrl+K` / `Cmd+K`) |
+| CostDashboard | `CostDashboard.tsx` | Token usage and cost visualization by model/project/day |
+| DiffViewer | `DiffViewer.tsx` | Inline diff display for Edit tool calls |
+| GitPanel | `GitPanel.tsx` | Git status and diff for the working directory |
+| ComparisonView | `ComparisonView.tsx` | Side-by-side multi-model response comparison |
+| ComparisonLauncher | `ComparisonLauncher.tsx` | UI to initiate a model comparison |
+| WorkflowManager | `WorkflowManager.tsx` | Workflow chain management and execution |
+| WorkflowEditor | `WorkflowEditor.tsx` | Create and edit workflow step definitions |
+| WorkflowProgress | `WorkflowProgress.tsx` | Step-by-step execution progress display |
+| SnippetManager | `SnippetManager.tsx` | CRUD interface for prompt snippets |
+| ShortcutSettings | `ShortcutSettings.tsx` | Keyboard shortcut customization UI |
+| ToastContainer | `ToastContainer.tsx` | Stacked toast notification display |
+| Toast | `Toast.tsx` | Individual toast notification |
+| ExportDialog | `ExportDialog.tsx` | Session export to Markdown or JSON |
+| MarketplacePanel | `MarketplacePanel.tsx` | Plugin browser with search, tag filters, install confirmation |
+| PermissionCard | `PermissionCard.tsx` | Allow/Deny prompt for tool calls |
+| PermissionDeniedCard | `PermissionDeniedCard.tsx` | Fallback card when tools were denied |
+| PermissionEditor | `PermissionEditor.tsx` | Permission rules management UI |
+| PermissionWizard | `PermissionWizard.tsx` | First-run permission mode selection |
+| HistoryPicker | `HistoryPicker.tsx` | Session history browser |
+| SettingsPopover | `SettingsPopover.tsx` | App settings (theme, size, sound, etc.) |
+| SlashCommandMenu | `SlashCommandMenu.tsx` | Autocomplete menu for `/` commands |
+| StatusBar | `StatusBar.tsx` | Cost/tokens/model display at bottom of conversation |
+| RetryBanner | `RetryBanner.tsx` | Retry state display for failed runs |
+| AttachmentChips | `AttachmentChips.tsx` | File/image attachment badges below input |
+| PopoverLayer | `PopoverLayer.tsx` | Portal layer for popover positioning |
 
 ### Performance Patterns
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -3,12 +3,37 @@
 If setup fails, run this first:
 
 ```bash
-npm run doctor
+npm run doctor        # macOS
+npm run doctor:win    # Windows (PowerShell)
 ```
 
 This checks your local environment and prints pass/fail status without changing your system.
 
-## Install Fails with "gyp" or "make" Errors
+---
+
+## Common (All Platforms)
+
+### App Launches but No Claude Response
+
+Verify Claude CLI is installed and authenticated:
+
+```bash
+claude --version
+```
+
+```bash
+claude
+```
+
+### Marketplace Shows "Failed to Load"
+
+Expected when offline. Marketplace needs internet access; core app features continue to work.
+
+---
+
+## macOS
+
+### Install Fails with "gyp" or "make" Errors
 
 Install Xcode Command Line Tools, then retry:
 
@@ -20,7 +45,7 @@ xcode-select --install
 npm install
 ```
 
-## Install Fails with `ModuleNotFoundError: No module named 'distutils'`
+### Install Fails with `ModuleNotFoundError: No module named 'distutils'`
 
 Python 3.12+ removed `distutils`. Install `setuptools`:
 
@@ -52,7 +77,7 @@ To undo that Python override later:
 npm config delete python
 ```
 
-## Install Fails with `fatal error: 'functional' file not found`
+### Install Fails with `fatal error: 'functional' file not found`
 
 C++ headers are missing/broken, usually due to Xcode CLT issues.
 
@@ -92,7 +117,7 @@ int main() { return 0; }
 EOF
 ```
 
-## Install Fails on `node-pty`
+### Install Fails on `node-pty`
 
 `node-pty` is native and requires macOS toolchains. Confirm:
 
@@ -102,19 +127,7 @@ EOF
 
 Then retry `npm install`.
 
-## App Launches but No Claude Response
-
-Verify Claude CLI is installed and authenticated:
-
-```bash
-claude --version
-```
-
-```bash
-claude
-```
-
-## `Alt+Space` Does Not Toggle
+### `Alt+Space` Does Not Toggle
 
 Grant Accessibility permissions:
 
@@ -124,13 +137,62 @@ Fallback shortcut:
 
 - `Cmd+Shift+K`
 
-## Marketplace Shows "Failed to Load"
-
-Expected when offline. Marketplace needs internet access; core app features continue to work.
-
-## Window Is Invisible / No UI
+### Window Is Invisible / No UI (macOS)
 
 Try:
 
 - `Cmd+Shift+K`
 - Confirm app is running from the menu bar tray
+
+---
+
+## Windows
+
+### `Ctrl+Space` Conflicts with IME
+
+The default Windows shortcut (`Ctrl+Space`) conflicts with Input Method Editors (IME) used for CJK languages. To resolve:
+
+- Open Settings in the app and change the toggle shortcut to a non-conflicting key combination.
+
+### `npm install` Fails with node-gyp Errors
+
+Native modules (like `node-pty`) require C++ build tools on Windows.
+
+1. Install Visual Studio Build Tools:
+   ```
+   winget install Microsoft.VisualStudio.2022.BuildTools
+   ```
+   Or download from https://visualstudio.microsoft.com/visual-cpp-build-tools/ and select "Desktop development with C++" workload.
+
+2. Retry:
+   ```bash
+   npm install
+   ```
+
+### App Launches but Overlay Is Not Visible
+
+This can happen with certain GPU drivers or remote desktop sessions.
+
+- Try launching with GPU acceleration disabled:
+  ```bash
+  npx electron . --disable-gpu
+  ```
+- Update your GPU drivers to the latest version.
+- Check if the app appears in the system tray (bottom-right notification area).
+
+### "Permission Denied" or Claude CLI Not Found
+
+Ensure `claude` is on your system PATH:
+
+```bash
+claude --version
+```
+
+If the command is not found:
+- Reinstall the Claude Code CLI.
+- Verify the install location is in your PATH environment variable.
+- Restart your terminal after PATH changes.
+
+### Spawn ENOENT Errors
+
+If you see `spawn ENOENT` errors, the app cannot find `claude.cmd` or `claude.exe`. The app prefers `.cmd`/`.exe` over POSIX shims on Windows. Ensure you have the Windows-native Claude CLI install (not WSL).

--- a/docs/oss-readiness-report.md
+++ b/docs/oss-readiness-report.md
@@ -1,7 +1,7 @@
 # CLUI Open-Source Readiness Report
 
-**Date:** 2026-03-12
-**Branch:** `oss-prep`
+**Date:** 2026-03-18
+**Branch:** `main`
 **Assessor:** Automated scan + manual review
 
 ---
@@ -44,7 +44,7 @@
 | Check | Result |
 |-------|--------|
 | Email addresses in source | None |
-| package.json author field | Not set (clean) |
+| package.json author field | Set (public) |
 | Git commit author | Will be visible in public repo history — see cutover plan |
 
 **Verdict:** Exclude `docs/protocol-captures/` and `docs/claude-permission-probe.md` from public repo.
@@ -54,8 +54,8 @@
 ## 3. Licensing
 
 ### Project License
-- **Current state:** No LICENSE file, no `license` field in package.json
-- **Action:** **MUST-FIX** — Add MIT license before publishing
+- **Current state:** MIT license in package.json
+- **Action:** Verify LICENSE file is present at repo root
 
 ### Dependencies (all MIT-compatible)
 | Package | License | Copyleft Risk |
@@ -69,6 +69,7 @@
 | remark-gfm | MIT | None |
 | @phosphor-icons/react | MIT | None |
 | tailwindcss | MIT | None |
+| vitest | MIT | None |
 | All devDependencies | MIT | None |
 
 **No GPL, AGPL, SSPL, or BUSL dependencies detected.**
@@ -81,7 +82,7 @@
 | `resources/trayTemplate*.png` | Original | Document in LICENSE |
 | Root marketing screenshots | Not included in current repo root | Optional to add later if needed for release collateral |
 
-**Verdict:** Add LICENSE file. ~~Verify notification.mp3 provenance~~ — resolved (replaced with CC0 generated chime).
+**Verdict:** License file present. Asset provenance verified.
 
 ---
 
@@ -89,23 +90,26 @@
 
 ### Prerequisites for Contributors
 - Node.js 18+ (for Electron 33)
-- macOS (primary platform — Electron transparent window, tray, node-pty)
+- macOS 13+ (production) or Windows 10+ (beta)
 - `claude` CLI installed and authenticated (core dependency)
+- macOS: Xcode Command Line Tools
+- Windows: Visual Studio Build Tools (for native modules)
 - Optional: `whisper-cli` or `whisper` + model for voice transcription
 
 ### Build System
 - `npm install` → `npm run dev` (hot-reload) or `npm run build` (production)
+- `npm run test` — Vitest test suite
 - Zero TypeScript errors confirmed
 - electron-vite handles main/preload/renderer bundling
 
 ### Missing for OSS
 | Item | Status | Priority |
 |------|--------|----------|
-| README.md | Missing | **Must-fix** |
-| CONTRIBUTING.md | Missing | Must-fix |
-| SECURITY.md | Missing | Must-fix |
-| CODE_OF_CONDUCT.md | Missing | Must-fix |
-| Architecture docs | Missing | Must-fix |
+| README.md | Done | -- |
+| CONTRIBUTING.md | Done | -- |
+| SECURITY.md | Done | -- |
+| CODE_OF_CONDUCT.md | Done | -- |
+| Architecture docs | Done | -- |
 | .env.example | Not needed | N/A — document explicitly |
 
 ---
@@ -151,11 +155,11 @@ No telemetry, analytics, auto-updater, or CDN dependencies.
 
 | Risk | Severity | Status |
 |------|----------|--------|
-| No LICENSE file | **Critical** | Fix in this branch |
-| No README | **Critical** | Fix in this branch |
+| No LICENSE file | **Critical** | Resolved — MIT license present |
+| No README | **Critical** | Resolved — README.md present |
 | Protocol captures contain local paths | **High** | Exclude from public repo |
 | notification.mp3 unknown provenance | **Medium** | Resolved — replaced with CC0 generated chime |
-| No CONTRIBUTING/SECURITY/COC docs | **Medium** | Fix in this branch |
+| No CONTRIBUTING/SECURITY/COC docs | **Medium** | Resolved — all present |
 | Internal docs (PRD, Codex reports) | **Low** | Exclude from public repo |
 | Probe utilities in src/main/probe/ | **Low** | Exclude from public repo |
-| macOS-only (no Windows/Linux) | **Low** | Document as known limitation |
+| macOS-only | **Low** | Resolved — macOS (production) + Windows (beta) supported |

--- a/docs/release-smoke-test.md
+++ b/docs/release-smoke-test.md
@@ -5,47 +5,47 @@
 ### Fresh Clone Bootstrap
 
 ```bash
-git clone https://github.com/lcoutodemos/clui-cc.git
-cd clui-cc
+git clone https://github.com/lfrmonteiro99/clui-cc-windows.git
+cd clui-cc-windows
 npm run doctor     # verify environment — all checks should pass
 npm install        # installs deps + runs postinstall (electron-builder install-app-deps + icon patch)
 npm run build      # production build — must exit 0 with no errors
+npm run test       # test suite — must exit 0 with no failures
 ```
 
 **Prerequisites check (verified by `npm run doctor`):**
-- macOS 13+
-- Xcode Command Line Tools installed (`xcode-select -p` returns a path)
-- macOS SDK available (`xcrun --sdk macosx --show-sdk-path` returns a path)
-- clang++ available with working C++ headers
+- macOS 13+ or Windows 10+
+- macOS: Xcode Command Line Tools installed (`xcode-select -p` returns a path)
+- macOS: macOS SDK available (`xcrun --sdk macosx --show-sdk-path` returns a path)
+- Windows: Visual Studio Build Tools (for native modules)
 - `node --version` returns 18+
-- `python3` available with `distutils` importable
+- `python3` available with `distutils` importable (macOS)
 - `claude --version` returns 2.1+
 
 **Expected output:**
 - `dist/main/index.js` — ~117 KB
 - `dist/preload/index.js` — ~6 KB
-- `dist/renderer/index.html` + `assets/index-*.js` (~1.5 MB) + `assets/index-*.css` (~25 KB)
+- `dist/renderer/index.html` + `assets/index-*.js` (~1.7 MB) + `assets/index-*.css` (~25 KB)
 
 ### TypeScript
 
 - `npm run build` — passes (uses esbuild, tolerant of some strict-mode warnings)
-- `npx tsc --noEmit` — has pre-existing warnings (68 as of v0.1.0, non-blocking)
+- `npx tsc --noEmit` — has pre-existing warnings (non-blocking)
   - These are narrowing/equality warnings from Zustand selector patterns and a legacy PTY file
   - Does NOT affect runtime behavior — electron-vite builds successfully
 
 ## Runtime Smoke Test Checklist
 
 ### Prerequisites
-- [ ] macOS 13+
-- [ ] Xcode Command Line Tools installed (`xcode-select -p` returns a path)
+- [ ] macOS 13+ or Windows 10+
 - [ ] Node.js 18+
 - [ ] `claude` CLI installed and authenticated (`claude --version` returns 2.1+)
 
 ### Startup
-- [ ] `npm run dev` or `./start.command` launches the app
+- [ ] `npm run dev` launches the app
 - [ ] Floating pill appears at bottom-center of screen
-- [ ] `Alt+Space` toggles visibility
-- [ ] Tray icon appears in menu bar
+- [ ] `Alt+Space` (macOS) / `Ctrl+Space` (Windows) toggles visibility
+- [ ] Tray icon appears in menu bar (macOS) / notification area (Windows)
 - [ ] Tray menu shows Quit option
 
 ### Tab Management
@@ -67,6 +67,63 @@ npm run build      # production build — must exit 0 with no errors
 - [ ] "Allow" lets the tool run
 - [ ] "Deny" blocks the tool
 - [ ] Permission denial is reflected in task completion
+
+### Command Palette
+- [ ] `Ctrl+K` (Windows) / `Cmd+K` (macOS) opens the command palette
+- [ ] Typing filters available commands
+- [ ] Selecting a command executes it
+- [ ] Escape closes the palette
+
+### Cost Dashboard
+- [ ] Open Settings → Usage section
+- [ ] Cost breakdown by model, project, and day displays correctly
+- [ ] Token counts are accurate after running prompts
+
+### Notifications
+- [ ] Toast notifications appear for task completion
+- [ ] OS-native desktop notifications fire when app is not focused
+- [ ] Notification preferences can be toggled in settings
+
+### Inline Diff Viewer
+- [ ] When Claude uses the Edit tool, a diff view appears
+- [ ] Added lines shown in green, removed lines shown in red
+- [ ] Diff is readable and correctly formatted
+
+### Git Context Panel
+- [ ] Git panel shows current branch name
+- [ ] Modified/added/deleted files are listed
+- [ ] Panel updates when working directory changes
+
+### Multi-Model Comparison
+- [ ] `/compare` command opens comparison launcher
+- [ ] Side-by-side responses are displayed
+- [ ] Results can be dismissed
+
+### Workflow Chains
+- [ ] `/workflow` command opens workflow manager
+- [ ] Can create, edit, and execute workflow steps
+- [ ] Progress display shows step-by-step execution
+
+### Tab Groups
+- [ ] Right-click tab opens context menu
+- [ ] Can create and name tab groups
+- [ ] Tab group headers are collapsible
+- [ ] Tabs can be moved between groups
+
+### Snippets
+- [ ] Snippet manager accessible from settings
+- [ ] Can create, edit, and delete prompt snippets
+- [ ] Snippets appear in the input suggestions
+
+### Session Export
+- [ ] `/export` command opens export dialog
+- [ ] Can export to Markdown or JSON format
+- [ ] Exported file contains the correct session content
+
+### Customizable Keyboard Shortcuts
+- [ ] Shortcut settings accessible from settings panel
+- [ ] Can rebind shortcuts to different key combinations
+- [ ] Conflict detection warns about duplicate bindings
 
 ### Settings
 - [ ] Three-dot button in tab strip opens settings popover
@@ -122,9 +179,10 @@ npm run build      # production build — must exit 0 with no errors
 
 ## Last Verified
 
-- **Date:** 2026-03-12
+- **Date:** 2026-03-18
 - **Node:** v22.x
 - **Electron:** 33.x
 - **Claude CLI:** 2.1.71
 - **macOS:** 15.x (Sequoia)
-- **Build result:** Pass (zero build errors)
+- **Windows:** 11 (26200)
+- **Build result:** Pass (zero build errors, zero test failures)

--- a/docs/slash-command-matrix.md
+++ b/docs/slash-command-matrix.md
@@ -3,7 +3,34 @@
 CLI Version: 2.1.63 | Date: 2026-03-08
 Test session: 450d2d0f-4b03-4761-8ecd-8d179998127d
 
-## Protocol Finding
+## App-Level Slash Commands
+
+These commands are intercepted by the CLUI app before reaching the CLI. Defined in `src/renderer/components/SlashCommandMenu.tsx`.
+
+| Command | Description | Behavior |
+|---------|-------------|----------|
+| `/clear` | Clear conversation history | Resets the active tab's message list |
+| `/compare` | Compare two models side-by-side | Opens ComparisonLauncher for multi-model comparison |
+| `/workflow` | Open workflow manager | Opens WorkflowManager for step-by-step prompt chains |
+| `/focus` | Set the current work focus | Inserted as prompt text (agent memory) |
+| `/claim` | Claim a work item by key | Inserted as prompt text (agent memory) |
+| `/done` | Mark the current work as done | Inserted as prompt text (agent memory) |
+| `/release` | Release the current claim | Inserted as prompt text (agent memory) |
+| `/memory` | Show active and recent shared work | Displays agent memory snapshot |
+| `/export` | Export session to Markdown or JSON | Opens ExportDialog |
+| `/cost` | Show token usage and cost | Opens CostDashboard |
+| `/model` | Show current model info | Displays session model metadata |
+| `/mcp` | Show MCP server status | Displays connected MCP servers |
+| `/skills` | Show available skills | Lists installed and available skills |
+| `/help` | Show available commands | Lists all slash commands |
+
+Commands marked as `insertOnly` (focus, claim, done, release) are inserted into the input bar as prompt prefixes rather than executed directly.
+
+## CLI Slash Commands (Passthrough)
+
+The following section documents commands that are passed through to the Claude Code CLI and their behavior in stream-json mode.
+
+### Protocol Finding
 
 `--input-format stream-json` is **completely broken** in CLI 2.1.63 (hangs forever, 0 events).
 The only working mode is one-shot `claude -p` with stdin closed + `--resume` for multi-turn.


### PR DESCRIPTION
## Summary
- Updated all 8 documentation files to reflect the current codebase state after feature additions (command palette, cost tracking, git context, diff viewer, notifications, comparisons, workflows, tab groups, snippets, shortcuts, session export, auto-attach)
- Added `npm run test` (Vitest) to all command reference tables (CLAUDE.md, AGENTS.md, release-smoke-test.md)
- Updated CLAUDE.md Key Files table with all new stores (10 total) and main process modules
- Rewrote ARCHITECTURE.md: multi-store state management, full component table (28 components), new main process subsections (CostTracker, GitContext, AutoAttach)
- Updated CONTRIBUTING.md: Windows support, correct clone URL, `npm run test` step, branch workflow, cross-platform bug reporting
- Updated AGENTS.md: all new key files, canonical types (CostRecord, GitStatus, TabGroup, Workflow, etc.), Vitest in stack table
- Added Windows troubleshooting section (IME conflicts, node-gyp, overlay visibility, PATH, ENOENT)
- Updated release-smoke-test.md: correct repo URL, Windows prerequisites, 12 new feature smoke test sections
- Updated oss-readiness-report.md: marked README/CONTRIBUTING/SECURITY/COC as Done, Windows support noted
- Added app-level slash command reference to slash-command-matrix.md (13 commands including /workflow)

## Test plan
- [ ] All doc file paths and references are correct
- [ ] No stale references to removed features or single-store architecture
- [ ] `npm run build` passes (docs are not compiled, but verifies no source changes leaked in)