### PR TITLE
QUAL-009: Add Content Security Policy to Electron renderer

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain, dialog, screen, globalShortcut, Tray, Menu, nativeImage, nativeTheme, shell, Notification } from 'electron'
+import { app, BrowserWindow, ipcMain, dialog, screen, globalShortcut, Tray, Menu, nativeImage, nativeTheme, shell, Notification, session } from 'electron'
 import { join } from 'path'
 import { existsSync, readdirSync, statSync, createReadStream } from 'fs'
 import { createInterface } from 'readline'
@@ -1053,6 +1053,28 @@ ipcMain.handle(IPC.NOTIFY_DESKTOP, (_event, title: string, body: string) => {
 app.whenReady().then(() => {
   agentMemory = new AgentMemory(join(app.getPath('userData'), 'agent-memory.json'))
   controlPlane.setAgentMemory(agentMemory)
+
+  // ─── Content Security Policy ───
+  session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
+    callback({
+      responseHeaders: {
+        ...details.responseHeaders,
+        'Content-Security-Policy': [
+          [
+            "default-src 'self'",
+            "script-src 'self'",
+            "style-src 'self' 'unsafe-inline'",
+            "img-src 'self' data:",
+            "font-src 'self'",
+            "connect-src 'self'",
+            "media-src 'self'",
+            "object-src 'none'",
+            "base-uri 'self'",
+          ].join('; '),
+        ],
+      },
+    })
+  })
 
   // macOS: become an accessory app. Accessory apps can have key windows (keyboard works)
   // without deactivating the currently active app (hover preserved in browsers).

--- a/tests/unit/csp.test.ts
+++ b/tests/unit/csp.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+
+// Test the CSP header value construction
+// The actual CSP is applied in main/index.ts via session.webRequest.onHeadersReceived
+
+const CSP_POLICY = [
+  "default-src 'self'",
+  "script-src 'self'",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data:",
+  "font-src 'self'",
+  "connect-src 'self'",
+  "media-src 'self'",
+  "object-src 'none'",
+  "base-uri 'self'",
+].join('; ')
+
+describe('Content Security Policy', () => {
+  it('blocks eval by not including unsafe-eval in script-src', () => {
+    expect(CSP_POLICY).not.toContain('unsafe-eval')
+  })
+
+  it('allows inline styles for Tailwind + Framer Motion', () => {
+    expect(CSP_POLICY).toContain("style-src 'self' 'unsafe-inline'")
+  })
+
+  it('allows data: URLs for screenshots/attachments', () => {
+    expect(CSP_POLICY).toContain("img-src 'self' data:")
+  })
+
+  it('blocks object/embed elements', () => {
+    expect(CSP_POLICY).toContain("object-src 'none'")
+  })
+
+  it('restricts base-uri to self', () => {
+    expect(CSP_POLICY).toContain("base-uri 'self'")
+  })
+
+  it('does not allow blob: or filesystem: in any directive', () => {
+    expect(CSP_POLICY).not.toContain('blob:')
+    expect(CSP_POLICY).not.toContain('filesystem:')
+  })
+
+  it('allows media-src for notification sounds', () => {
+    expect(CSP_POLICY).toContain("media-src 'self'")
+  })
+})


### PR DESCRIPTION
## Summary
Closes #80

Adds defense-in-depth CSP via `session.webRequest.onHeadersReceived` in main process.

**Policy:**
- `default-src 'self'` — blocks all external resources
- `script-src 'self'` — blocks eval, inline scripts
- `style-src 'self' 'unsafe-inline'` — allows Tailwind/Framer Motion inline styles
- `img-src 'self' data:` — allows screenshot/attachment data URLs
- `media-src 'self'` — allows notification sound
- `object-src 'none'` — blocks Flash/plugins
- `base-uri 'self'` — prevents base tag hijacking

## Test plan
- [x] `npm run build` — zero errors
- [x] `npx vitest run` — 348 tests pass (44 files)
- [ ] Manual: app functions normally, no CSP violations in DevTools console