### PR TITLE
QUAL-014: Add global error handlers for unhandled rejections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@playwright/test": "^1.58.2",
         "@tailwindcss/vite": "^4.2.1",
         "@testing-library/jest-dom": "^6.9.1",
-        "@testing-library/react": "^16.3.0",
+        "@testing-library/react": "^16.3.2",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@typescript-eslint/eslint-plugin": "^8.57.1",
@@ -1583,6 +1583,8 @@
     },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1606,6 +1608,8 @@
     },
     "node_modules/@testing-library/react": {
       "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "@playwright/test": "^1.58.2",
     "@tailwindcss/vite": "^4.2.1",
     "@testing-library/jest-dom": "^6.9.1",
-    "@testing-library/react": "^16.3.0",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@typescript-eslint/eslint-plugin": "^8.57.1",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1059,6 +1059,16 @@ ipcMain.handle(IPC.NOTIFY_DESKTOP, (_event, title: string, body: string) => {
   }
 })
 
+// ─── Global error handlers ───
+
+process.on('unhandledRejection', (reason) => {
+  log(`[FATAL] Unhandled rejection: ${reason instanceof Error ? `${reason.message}\n${reason.stack}` : String(reason)}`)
+})
+
+process.on('uncaughtException', (error) => {
+  log(`[FATAL] Uncaught exception: ${error.message}\n${error.stack}`)
+})
+
 // ─── App Lifecycle ───
 
 app.whenReady().then(() => {

--- a/tests/unit/global-error-handlers.test.ts
+++ b/tests/unit/global-error-handlers.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+// Verify that global error handlers are registered in main/index.ts source code
+
+const mainSource = readFileSync(join(__dirname, '../../src/main/index.ts'), 'utf-8')
+
+describe('Global error handlers', () => {
+  it('registers unhandledRejection handler', () => {
+    expect(mainSource).toContain("process.on('unhandledRejection'")
+  })
+
+  it('registers uncaughtException handler', () => {
+    expect(mainSource).toContain("process.on('uncaughtException'")
+  })
+
+  it('logs errors with severity prefix', () => {
+    expect(mainSource).toMatch(/\[FATAL\].*unhandled|unhandledRejection/i)
+  })
+})


### PR DESCRIPTION
## Summary
Closes #99

- `process.on('unhandledRejection')` logs with [FATAL] prefix to debug log
- `process.on('uncaughtException')` logs with [FATAL] prefix to debug log
- Also installs missing @testing-library/react and @testing-library/jest-dom devDependencies (required by tests/setup.ts)

## Test plan
- [x] `npm run build` — zero errors
- [x] `npx vitest run` — tests pass