### PR TITLE
QUAL-019: Whisper provisioning toast notifications

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1116,7 +1116,7 @@ app.whenReady().then(() => {
     // Whisper provisioning — auto-download binary + model on first boot
     ensureWhisper((status: WhisperProvisionStatus) => {
       log(`[WhisperProvisioner] ${status.stage}${status.progress != null ? ` ${status.progress}%` : ''}${status.error ? ` — ${status.error}` : ''}`)
-      broadcast('clui:whisper-status', status)
+      broadcast(IPC.WHISPER_STATUS, status)
     }).catch((err: Error) => log(`Whisper provisioning error: ${err.message}`))
   }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -92,6 +92,7 @@ export interface CluiAPI {
   onTabStatusChange(callback: (tabId: string, newStatus: string, oldStatus: string) => void): () => void
   onError(callback: (tabId: string, error: EnrichedError) => void): () => void
   onSkillStatus(callback: (status: { name: string; state: string; error?: string; reason?: string }) => void): () => void
+  onWhisperStatus(callback: (status: { stage: string; progress?: number; error?: string }) => void): () => void
   onWindowShown(callback: () => void): () => void
 }
 
@@ -202,6 +203,12 @@ const api: CluiAPI = {
     const handler = (_e: Electron.IpcRendererEvent, status: any) => callback(status)
     ipcRenderer.on(IPC.SKILL_STATUS, handler)
     return () => ipcRenderer.removeListener(IPC.SKILL_STATUS, handler)
+  },
+
+  onWhisperStatus: (callback) => {
+    const handler = (_e: Electron.IpcRendererEvent, status: any) => callback(status)
+    ipcRenderer.on(IPC.WHISPER_STATUS, handler)
+    return () => ipcRenderer.removeListener(IPC.WHISPER_STATUS, handler)
   },
 
   onWindowShown: (callback) => {

--- a/src/renderer/hooks/useClaudeEvents.ts
+++ b/src/renderer/hooks/useClaudeEvents.ts
@@ -61,11 +61,26 @@ export function useClaudeEvents() {
       }
     })
 
+    let whisperToastShown = false
+    const unsubWhisper = window.clui.onWhisperStatus((status) => {
+      const { useNotificationStore } = require('../stores/notificationStore')
+      const addToast = useNotificationStore.getState().addToast
+      if (status.stage === 'downloading-binary' && !whisperToastShown) {
+        whisperToastShown = true
+        addToast({ type: 'info', title: 'Downloading voice engine...', duration: 8000 })
+      } else if (status.stage === 'ready' && whisperToastShown) {
+        addToast({ type: 'success', title: 'Voice input ready' })
+      } else if (status.stage === 'error') {
+        addToast({ type: 'warning', title: 'Voice download failed', message: status.error || 'Retry on next launch' })
+      }
+    })
+
     return () => {
       unsubEvent()
       unsubStatus()
       unsubError()
       unsubSkill()
+      unsubWhisper()
       if (rafIdRef.current) cancelAnimationFrame(rafIdRef.current)
       chunkBufferRef.current.clear()
     }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -543,6 +543,9 @@ export const IPC = {
   TAB_STATUS_CHANGE: 'clui:tab-status-change',
   ENRICHED_ERROR: 'clui:enriched-error',
 
+  // Whisper provisioning
+  WHISPER_STATUS: 'clui:whisper-status',
+
   // Error logging
   LOG_RENDERER_ERROR: 'clui:log-renderer-error',
 


### PR DESCRIPTION
Closes #104 — Added WHISPER_STATUS IPC channel, preload listener, and toast notifications: 'Downloading voice engine...' on start, 'Voice input ready' on complete, warning on failure.