### PR TITLE
UX-001: Default shortcut Alt+Space + first-launch hint toast

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1208,6 +1208,11 @@ app.whenReady().then(() => {
     // Secondary shortcut always registered
     globalShortcut.register('CommandOrControl+Shift+K', () => toggleWindow('shortcut Cmd/Ctrl+Shift+K'))
 
+    // Notify renderer of the active shortcut for first-launch hint toast
+    mainWindow?.webContents.once('did-finish-load', () => {
+      mainWindow?.webContents.send(IPC.SHORTCUT_REGISTERED, primaryShortcut)
+    })
+
     const trayIconPath = join(__dirname, process.platform === 'darwin' ? '../../resources/trayTemplate.png' : '../../resources/icon.png')
     const trayIcon = nativeImage.createFromPath(trayIconPath)
     if (process.platform === 'darwin') {

--- a/src/main/shortcut-config.ts
+++ b/src/main/shortcut-config.ts
@@ -18,10 +18,10 @@ export interface ShortcutConfig {
 /**
  * Returns the platform-appropriate default shortcut.
  * - macOS: Alt+Space (doesn't conflict with Spotlight, which uses Cmd+Space)
- * - Windows: Ctrl+Space (may conflict with IMEs — that's why we support alternatives)
+ * - Windows: Alt+Space (Ctrl+Space conflicts with IMEs on most Windows setups)
  */
 export function getDefaultShortcut(): string {
-  return process.platform === 'win32' ? 'CommandOrControl+Space' : 'Alt+Space'
+  return 'Alt+Space'
 }
 
 /**
@@ -31,7 +31,6 @@ export function getDefaultShortcut(): string {
 export function getSafeAlternatives(): string[] {
   return [
     'CommandOrControl+Shift+Space',
-    'CommandOrControl+`',
     'CommandOrControl+Shift+K',
     'Alt+Shift+Space',
     'CommandOrControl+Alt+Space',

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -94,6 +94,7 @@ export interface CluiAPI {
   onSkillStatus(callback: (status: { name: string; state: string; error?: string; reason?: string }) => void): () => void
   onWhisperStatus(callback: (status: { stage: string; progress?: number; error?: string }) => void): () => void
   onWindowShown(callback: () => void): () => void
+  onShortcutRegistered(callback: (shortcut: string) => void): () => void
 
   // Terminal
   terminalAvailable(): Promise<boolean>
@@ -232,6 +233,11 @@ const api: CluiAPI = {
     const handler = () => callback()
     ipcRenderer.on(IPC.WINDOW_SHOWN, handler)
     return () => ipcRenderer.removeListener(IPC.WINDOW_SHOWN, handler)
+  },
+  onShortcutRegistered: (callback) => {
+    const handler = (_: unknown, shortcut: string) => callback(shortcut)
+    ipcRenderer.on(IPC.SHORTCUT_REGISTERED, handler)
+    return () => ipcRenderer.removeListener(IPC.SHORTCUT_REGISTERED, handler)
   },
 
   // Terminal

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -41,6 +41,7 @@ import { FileContextMenu } from './components/FileContextMenu'
 import { useColors, useThemeStore, spacing } from './theme'
 import { useFilePeekStore } from './stores/filePeekStore'
 import { useContextMenuStore } from './stores/contextMenuStore'
+import { useNotificationStore } from './stores/notificationStore'
 
 const TRANSITION = { duration: 0.26, ease: [0.4, 0, 0.1, 1] as const }
 
@@ -253,6 +254,23 @@ export default function App() {
       document.removeEventListener('mousemove', onMouseMove)
       document.removeEventListener('mouseleave', onMouseLeave)
     }
+  }, [])
+
+  // Show shortcut hint toast on first launch
+  useEffect(() => {
+    const HINT_KEY = 'clui:shortcutHintShown'
+    if (localStorage.getItem(HINT_KEY)) return
+    const cleanup = window.clui.onShortcutRegistered((shortcut: string) => {
+      const display = shortcut.replace('CommandOrControl', 'Ctrl').replace('Alt', 'Alt')
+      useNotificationStore.getState().addToast({
+        type: 'info',
+        title: `Press ${display} to show/hide Clui`,
+        message: 'Ctrl+Shift+K also works as backup',
+        duration: 8000,
+      })
+      localStorage.setItem(HINT_KEY, '1')
+    })
+    return cleanup
   }, [])
 
   // Layout dimensions — expandedUI widens and heightens the panel; terminal/comparison mode widens further

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -574,6 +574,9 @@ export const IPC = {
   // Error logging
   LOG_RENDERER_ERROR: 'clui:log-renderer-error',
 
+  // Shortcut hint
+  SHORTCUT_REGISTERED: 'clui:shortcut-registered',
+
   // File peek
   FILE_READ: 'clui:file-read',
   FILE_REVEAL: 'clui:file-reveal',

--- a/tests/unit/shortcut-config.test.ts
+++ b/tests/unit/shortcut-config.test.ts
@@ -31,13 +31,7 @@ describe('shortcut-config', () => {
   })
 
   describe('getDefaultShortcut', () => {
-    it('returns Ctrl+Space on win32', () => {
-      restorePlatform = mockPlatform('win32')
-      expect(getDefaultShortcut()).toBe('CommandOrControl+Space')
-    })
-
-    it('returns Alt+Space on darwin', () => {
-      restorePlatform = mockPlatform('darwin')
+    it('returns Alt+Space on all platforms', () => {
       expect(getDefaultShortcut()).toBe('Alt+Space')
     })
   })
@@ -58,11 +52,10 @@ describe('shortcut-config', () => {
 
   describe('loadShortcutConfig', () => {
     it('returns default when config file does not exist', () => {
-      restorePlatform = mockPlatform('win32')
       mockExistsSync.mockReturnValue(false)
 
       const config = loadShortcutConfig()
-      expect(config.primary).toBe('CommandOrControl+Space')
+      expect(config.primary).toBe('Alt+Space')
     })
 
     it('returns saved shortcut when config file exists', () => {
@@ -74,12 +67,11 @@ describe('shortcut-config', () => {
     })
 
     it('falls back to default on corrupt config file', () => {
-      restorePlatform = mockPlatform('win32')
       mockExistsSync.mockReturnValue(true)
       mockReadFileSync.mockReturnValue('not json!!!!')
 
       const config = loadShortcutConfig()
-      expect(config.primary).toBe('CommandOrControl+Space')
+      expect(config.primary).toBe('Alt+Space')
     })
   })
 


### PR DESCRIPTION
## Summary
- Change default toggle shortcut to `Alt+Space` on all platforms (was `Ctrl+Space` on Windows which conflicts with IMEs)
- Remove `Ctrl+`` from fallback alternatives
- Show info toast on first launch: "Press Alt+Space to show/hide Clui" + backup shortcut
- Toast only appears once (stored in localStorage)

## Test plan
- [ ] `npm run test` — 501 tests pass
- [ ] First launch shows toast with active shortcut
- [ ] Second launch does NOT show toast
- [ ] Alt+Space toggles the overlay
- [ ] Ctrl+Shift+K works as backup