### PR TITLE
CLUI-CLI-005: Add full-height compose editor (Ctrl+G)

### DIFF
--- a/src/renderer/components/ComposeEditor.tsx
+++ b/src/renderer/components/ComposeEditor.tsx
@@ -1,0 +1,246 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+import { X, PaperPlaneRight } from '@phosphor-icons/react'
+import { useColors } from '../theme'
+
+interface ComposeEditorProps {
+  isOpen: boolean
+  initialText: string
+  onSubmit: (text: string) => void
+  onCancel: (draft: string) => void
+  disabled?: boolean
+}
+
+/**
+ * Full-height compose editor overlay for drafting complex, multi-paragraph prompts.
+ * Opens via Ctrl+G (Windows) / Cmd+G (macOS).
+ *
+ * - Monospaced textarea with line numbers
+ * - Top bar: title, char/line counts, Cancel (Esc) + Submit (Ctrl+Enter)
+ * - Framer Motion slide-up animation
+ * - All colors from useColors() hook
+ */
+export function ComposeEditor({ isOpen, initialText, onSubmit, onCancel, disabled }: ComposeEditorProps) {
+  const colors = useColors()
+  const [text, setText] = useState(initialText)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const hasInitialized = useRef(false)
+
+  // Sync initial text when editor opens
+  useEffect(() => {
+    if (isOpen) {
+      setText(initialText)
+      hasInitialized.current = true
+      // Focus textarea after animation frame
+      requestAnimationFrame(() => {
+        const el = textareaRef.current
+        if (el) {
+          el.focus()
+          // Place cursor at end
+          el.selectionStart = el.value.length
+          el.selectionEnd = el.value.length
+        }
+      })
+    }
+  }, [isOpen, initialText])
+
+  const handleSubmit = useCallback(() => {
+    if (disabled) return
+    const trimmed = text.trim()
+    if (!trimmed) return
+    onSubmit(trimmed)
+  }, [text, onSubmit, disabled])
+
+  const handleCancel = useCallback(() => {
+    onCancel(text)
+  }, [text, onCancel])
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Escape') {
+      e.preventDefault()
+      handleCancel()
+      return
+    }
+    if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+      e.preventDefault()
+      handleSubmit()
+      return
+    }
+  }, [handleCancel, handleSubmit])
+
+  const lineCount = text.split('\n').length
+  const charCount = text.length
+
+  // Generate line number gutter text
+  const lineNumbers = Array.from({ length: Math.max(lineCount, 1) }, (_, i) => i + 1)
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <motion.div
+          key="compose-editor"
+          data-testid="compose-editor"
+          initial={{ opacity: 0, y: 40 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: 40 }}
+          transition={{ duration: 0.2, ease: [0.25, 0.46, 0.45, 0.94] }}
+          style={{
+            position: 'absolute',
+            inset: 0,
+            zIndex: 50,
+            display: 'flex',
+            flexDirection: 'column',
+            background: colors.containerBg,
+            borderRadius: 12,
+            border: `1px solid ${colors.containerBorder}`,
+            overflow: 'hidden',
+          }}
+        >
+          {/* Top bar */}
+          <div
+            data-testid="compose-top-bar"
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              padding: '8px 12px',
+              borderBottom: `1px solid ${colors.containerBorder}`,
+              background: colors.surfacePrimary,
+              flexShrink: 0,
+            }}
+          >
+            <span
+              style={{
+                fontSize: 13,
+                fontWeight: 600,
+                color: colors.textPrimary,
+              }}
+            >
+              Compose Prompt
+            </span>
+
+            <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+              {/* Char / line count */}
+              <span
+                data-testid="compose-counts"
+                style={{
+                  fontSize: 11,
+                  color: colors.textTertiary,
+                  fontFamily: 'monospace',
+                }}
+              >
+                {charCount} char{charCount !== 1 ? 's' : ''} · {lineCount} line{lineCount !== 1 ? 's' : ''}
+              </span>
+
+              {/* Cancel button */}
+              <button
+                data-testid="compose-cancel"
+                onClick={handleCancel}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 4,
+                  padding: '4px 8px',
+                  borderRadius: 6,
+                  border: `1px solid ${colors.containerBorder}`,
+                  background: 'transparent',
+                  color: colors.textSecondary,
+                  fontSize: 12,
+                  cursor: 'pointer',
+                }}
+                title="Cancel (Esc)"
+              >
+                <X size={14} />
+                <span>Esc</span>
+              </button>
+
+              {/* Submit button */}
+              <button
+                data-testid="compose-submit"
+                onClick={handleSubmit}
+                disabled={disabled || text.trim().length === 0}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 4,
+                  padding: '4px 10px',
+                  borderRadius: 6,
+                  border: 'none',
+                  background: disabled || text.trim().length === 0
+                    ? colors.sendDisabled
+                    : colors.sendBg,
+                  color: colors.textOnAccent,
+                  fontSize: 12,
+                  fontWeight: 500,
+                  cursor: disabled || text.trim().length === 0 ? 'not-allowed' : 'pointer',
+                }}
+                title="Submit (Ctrl+Enter)"
+              >
+                <PaperPlaneRight size={14} />
+                <span>Ctrl+Enter</span>
+              </button>
+            </div>
+          </div>
+
+          {/* Editor area with line numbers */}
+          <div
+            style={{
+              flex: 1,
+              display: 'flex',
+              overflow: 'hidden',
+              minHeight: 0,
+            }}
+          >
+            {/* Line number gutter */}
+            <div
+              data-testid="compose-line-numbers"
+              style={{
+                padding: '12px 0',
+                paddingRight: 8,
+                paddingLeft: 12,
+                textAlign: 'right',
+                fontFamily: 'monospace',
+                fontSize: 13,
+                lineHeight: '20px',
+                color: colors.textTertiary,
+                userSelect: 'none',
+                flexShrink: 0,
+                overflow: 'hidden',
+                borderRight: `1px solid ${colors.containerBorder}`,
+                background: colors.surfacePrimary,
+              }}
+            >
+              {lineNumbers.map((n) => (
+                <div key={n}>{n}</div>
+              ))}
+            </div>
+
+            {/* Textarea */}
+            <textarea
+              ref={textareaRef}
+              data-testid="compose-textarea"
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              onKeyDown={handleKeyDown}
+              spellCheck={false}
+              style={{
+                flex: 1,
+                padding: '12px 16px',
+                background: 'transparent',
+                color: colors.textPrimary,
+                fontFamily: 'monospace',
+                fontSize: 13,
+                lineHeight: '20px',
+                border: 'none',
+                outline: 'none',
+                resize: 'none',
+                overflow: 'auto',
+              }}
+              placeholder="Write your prompt here..."
+            />
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  )
+}

--- a/src/renderer/components/InputBar.tsx
+++ b/src/renderer/components/InputBar.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useCallback, useEffect, useLayoutEffect } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { Microphone, ArrowUp, SpinnerGap, X, Check, Sparkle, Lightning } from '@phosphor-icons/react'
+import { ComposeEditor } from './ComposeEditor'
 import { useSessionStore, AVAILABLE_MODELS } from '../stores/sessionStore'
 import { useAgentMemoryStore } from '../stores/agentMemoryStore'
 import { useComparisonStore } from '../stores/comparisonStore'
@@ -70,6 +71,7 @@ export function InputBar() {
   const [slashFilter, setSlashFilter] = useState<string | null>(null)
   const [slashIndex, setSlashIndex] = useState(0)
   const [isMultiLine, setIsMultiLine] = useState(false)
+  const [isComposeOpen, setIsComposeOpen] = useState(false)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const wrapperRef = useRef<HTMLDivElement>(null)
   const measureRef = useRef<HTMLTextAreaElement | null>(null)
@@ -97,6 +99,9 @@ export function InputBar() {
   const preferredModel = useSessionStore((s) => s.preferredModel)
   const activeTabId = useSessionStore((s) => s.activeTabId)
   const tab = useSessionStore((s) => s.tabs.find((t) => t.id === s.activeTabId))
+  const composeDraft = useSessionStore((s) => s.composeDrafts[s.activeTabId] ?? '')
+  const setComposeDraft = useSessionStore((s) => s.setComposeDraft)
+  const clearComposeDraft = useSessionStore((s) => s.clearComposeDraft)
   const snippets = useSnippetStore((s) => s.snippets)
   const colors = useColors()
   const isBusy = tab?.status === 'running' || tab?.status === 'connecting'
@@ -137,6 +142,51 @@ export function InputBar() {
     window.addEventListener('clui-focus-input', onFocusInput as EventListener)
     return () => window.removeEventListener('clui-focus-input', onFocusInput as EventListener)
   }, [])
+
+  // Close compose editor on tab switch
+  useEffect(() => {
+    if (isComposeOpen) {
+      setIsComposeOpen(false)
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeTabId])
+
+  // Ctrl+G / Cmd+G — open compose editor
+  useEffect(() => {
+    const handleGlobalKeyDown = (e: KeyboardEvent) => {
+      const isMod = e.ctrlKey || e.metaKey
+      if (isMod && e.key === 'g') {
+        e.preventDefault()
+        if (isComposeOpen) {
+          setIsComposeOpen(false)
+        } else if (tab?.status !== 'connecting') {
+          setIsComposeOpen(true)
+        }
+      }
+    }
+    window.addEventListener('keydown', handleGlobalKeyDown)
+    return () => window.removeEventListener('keydown', handleGlobalKeyDown)
+  }, [isComposeOpen, tab?.status])
+
+  const handleComposeSubmit = useCallback((text: string) => {
+    setIsComposeOpen(false)
+    clearComposeDraft(activeTabId)
+    setInput('')
+    sendMessage(text)
+    requestAnimationFrame(() => textareaRef.current?.focus())
+  }, [activeTabId, clearComposeDraft, sendMessage])
+
+  const handleComposeCancel = useCallback((draft: string) => {
+    setIsComposeOpen(false)
+    if (draft.trim()) {
+      setComposeDraft(activeTabId, draft)
+    } else {
+      clearComposeDraft(activeTabId)
+    }
+    // Put the draft text back in the inline input
+    setInput(draft)
+    requestAnimationFrame(() => textareaRef.current?.focus())
+  }, [activeTabId, setComposeDraft, clearComposeDraft])
 
   const buildCurrentExportData = useCallback((): SessionExportData | null => {
     if (!tab || tab.messages.length === 0) {
@@ -818,6 +868,15 @@ export function InputBar() {
 
       {/* Prompt lint warnings */}
       {lintWarnings.length > 0 && <PromptLintBar warnings={lintWarnings} />}
+
+      {/* Compose editor overlay */}
+      <ComposeEditor
+        isOpen={isComposeOpen}
+        initialText={isComposeOpen ? (composeDraft || input) : ''}
+        onSubmit={handleComposeSubmit}
+        onCancel={handleComposeCancel}
+        disabled={isBusy}
+      />
     </div>
   )
 }

--- a/src/renderer/stores/sessionStore.impl.ts
+++ b/src/renderer/stores/sessionStore.impl.ts
@@ -79,6 +79,9 @@ interface State {
   // Cost dashboard state
   costDashboardOpen: boolean
 
+  // Compose editor per-tab drafts
+  composeDrafts: Record<string, string>
+
   // Actions
   initStaticInfo: () => Promise<void>
   setPreferredModel: (model: string | null) => void
@@ -116,6 +119,8 @@ interface State {
   markAgentDone: (note?: string) => Promise<boolean>
   releaseAgentWork: () => Promise<boolean>
   setTabGroup: (tabId: string, groupId: string | undefined) => void
+  setComposeDraft: (tabId: string, draft: string) => void
+  clearComposeDraft: (tabId: string) => void
   retryTab: (tabId: string) => void
   stopRetrying: (tabId: string) => void
   handleNormalizedEvent: (tabId: string, event: NormalizedEvent) => void
@@ -304,6 +309,9 @@ export const useSessionStore = create<State>((set, get) => ({
   // Cost dashboard
   costDashboardOpen: false,
 
+  // Compose editor drafts
+  composeDrafts: {},
+
   initStaticInfo: async () => {
     try {
       const result = await window.clui.start()
@@ -488,6 +496,7 @@ export const useSessionStore = create<State>((set, get) => ({
   closeTab: (tabId) => {
     clearRetryTimer(tabId)
     useTokenBudgetStore.getState().resetTab(tabId)
+    get().clearComposeDraft(tabId)
     window.clui.closeTab(tabId).catch(() => {})
 
     const s = get()
@@ -778,6 +787,20 @@ export const useSessionStore = create<State>((set, get) => ({
     set((s) => ({
       tabs: s.tabs.map((t) => (t.id === tabId ? { ...t, groupId } : t)),
     }))
+  },
+
+  setComposeDraft: (tabId, draft) => {
+    set((s) => ({
+      composeDrafts: { ...s.composeDrafts, [tabId]: draft },
+    }))
+  },
+
+  clearComposeDraft: (tabId) => {
+    set((s) => {
+      const next = { ...s.composeDrafts }
+      delete next[tabId]
+      return { composeDrafts: next }
+    })
   },
 
   retryTab: (tabId) => {

--- a/src/shared/keyboard-shortcuts.ts
+++ b/src/shared/keyboard-shortcuts.ts
@@ -8,6 +8,7 @@ export type ShortcutActionId =
   | 'new-tab'
   | 'close-tab'
   | 'toggle-expand'
+  | 'compose-editor'
   | 'focus-input'
   | 'command-palette'
   | 'open-history'
@@ -39,6 +40,7 @@ const SHORTCUT_DEFINITIONS: ShortcutDefinition[] = [
   { id: 'new-tab', label: 'New Tab', category: 'navigation', windows: 'Ctrl+T', mac: 'Cmd+T' },
   { id: 'close-tab', label: 'Close Tab', category: 'navigation', windows: 'Ctrl+W', mac: 'Cmd+W' },
   { id: 'toggle-expand', label: 'Toggle Expand', category: 'view', windows: 'Ctrl+E', mac: 'Cmd+E' },
+  { id: 'compose-editor', label: 'Compose Editor', category: 'view', windows: 'Ctrl+G', mac: 'Cmd+G' },
   { id: 'focus-input', label: 'Focus Input', category: 'view', windows: 'Ctrl+L', mac: 'Cmd+L' },
   { id: 'toggle-theme', label: 'Toggle Theme', category: 'view', windows: 'Ctrl+D', mac: 'Cmd+D' },
   { id: 'command-palette', label: 'Command Palette', category: 'actions', windows: 'Ctrl+K', mac: 'Cmd+K' },

--- a/tests/renderer/components/ComposeEditor.test.tsx
+++ b/tests/renderer/components/ComposeEditor.test.tsx
@@ -1,0 +1,222 @@
+// @vitest-environment jsdom
+
+import React from 'react'
+import { act, fireEvent, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ComposeEditor } from '../../../src/renderer/components/ComposeEditor'
+import { InputBar } from '../../../src/renderer/components/InputBar'
+import { useSessionStore } from '../../../src/renderer/stores/sessionStore'
+import { renderWithProviders, resetTestState, makeTab } from '../testUtils'
+
+describe('ComposeEditor', () => {
+  const onSubmit = vi.fn()
+  const onCancel = vi.fn()
+
+  beforeEach(() => {
+    resetTestState()
+    onSubmit.mockReset()
+    onCancel.mockReset()
+  })
+
+  it('renders when open', () => {
+    renderWithProviders(
+      <ComposeEditor isOpen={true} initialText="" onSubmit={onSubmit} onCancel={onCancel} />,
+    )
+    expect(screen.getByTestId('compose-editor')).toBeInTheDocument()
+    expect(screen.getByTestId('compose-textarea')).toBeInTheDocument()
+    expect(screen.getByTestId('compose-top-bar')).toBeInTheDocument()
+  })
+
+  it('is hidden when closed', () => {
+    renderWithProviders(
+      <ComposeEditor isOpen={false} initialText="" onSubmit={onSubmit} onCancel={onCancel} />,
+    )
+    expect(screen.queryByTestId('compose-editor')).not.toBeInTheDocument()
+  })
+
+  it('pre-fills with initialText when opened', () => {
+    renderWithProviders(
+      <ComposeEditor isOpen={true} initialText="Hello world" onSubmit={onSubmit} onCancel={onCancel} />,
+    )
+    expect(screen.getByTestId('compose-textarea')).toHaveValue('Hello world')
+  })
+
+  it('Escape closes without submitting and preserves draft', () => {
+    renderWithProviders(
+      <ComposeEditor isOpen={true} initialText="draft text" onSubmit={onSubmit} onCancel={onCancel} />,
+    )
+    const textarea = screen.getByTestId('compose-textarea')
+    fireEvent.keyDown(textarea, { key: 'Escape' })
+
+    expect(onCancel).toHaveBeenCalledWith('draft text')
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('Ctrl+Enter submits and closes', () => {
+    renderWithProviders(
+      <ComposeEditor isOpen={true} initialText="submit me" onSubmit={onSubmit} onCancel={onCancel} />,
+    )
+    const textarea = screen.getByTestId('compose-textarea')
+    fireEvent.keyDown(textarea, { key: 'Enter', ctrlKey: true })
+
+    expect(onSubmit).toHaveBeenCalledWith('submit me')
+    expect(onCancel).not.toHaveBeenCalled()
+  })
+
+  it('does not submit empty text', () => {
+    renderWithProviders(
+      <ComposeEditor isOpen={true} initialText="" onSubmit={onSubmit} onCancel={onCancel} />,
+    )
+    const textarea = screen.getByTestId('compose-textarea')
+    fireEvent.keyDown(textarea, { key: 'Enter', ctrlKey: true })
+
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('does not submit when disabled', () => {
+    renderWithProviders(
+      <ComposeEditor isOpen={true} initialText="text" onSubmit={onSubmit} onCancel={onCancel} disabled />,
+    )
+    const textarea = screen.getByTestId('compose-textarea')
+    fireEvent.keyDown(textarea, { key: 'Enter', ctrlKey: true })
+
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('shows character and line count for initial text', () => {
+    act(() => {
+      renderWithProviders(
+        <ComposeEditor isOpen={true} initialText="" onSubmit={onSubmit} onCancel={onCancel} />,
+      )
+    })
+    const counts = screen.getByTestId('compose-counts')
+    expect(counts.textContent).toContain('0 chars')
+    expect(counts.textContent).toContain('1 line')
+  })
+
+  it('shows correct counts for multi-line initial text', () => {
+    act(() => {
+      renderWithProviders(
+        <ComposeEditor isOpen={true} initialText={'line1\nline2\nline3'} onSubmit={onSubmit} onCancel={onCancel} />,
+      )
+    })
+    const counts = screen.getByTestId('compose-counts')
+    expect(counts.textContent).toContain('17 chars')
+    expect(counts.textContent).toContain('3 lines')
+  })
+
+  it('Cancel button calls onCancel with current text', () => {
+    renderWithProviders(
+      <ComposeEditor isOpen={true} initialText="some text" onSubmit={onSubmit} onCancel={onCancel} />,
+    )
+    fireEvent.click(screen.getByTestId('compose-cancel'))
+
+    expect(onCancel).toHaveBeenCalledWith('some text')
+  })
+
+  it('Submit button calls onSubmit with trimmed text', () => {
+    renderWithProviders(
+      <ComposeEditor isOpen={true} initialText="  submit me  " onSubmit={onSubmit} onCancel={onCancel} />,
+    )
+    fireEvent.click(screen.getByTestId('compose-submit'))
+
+    expect(onSubmit).toHaveBeenCalledWith('submit me')
+  })
+
+  it('renders line numbers matching the number of lines', () => {
+    act(() => {
+      renderWithProviders(
+        <ComposeEditor isOpen={true} initialText={'a\nb\nc'} onSubmit={onSubmit} onCancel={onCancel} />,
+      )
+    })
+    const gutter = screen.getByTestId('compose-line-numbers')
+    // Initial text "a\nb\nc" has 3 lines
+    expect(gutter.children).toHaveLength(3)
+    expect(gutter.children[0].textContent).toBe('1')
+    expect(gutter.children[2].textContent).toBe('3')
+  })
+})
+
+describe('ComposeEditor draft persistence', () => {
+  beforeEach(() => {
+    resetTestState()
+    useSessionStore.setState({
+      tabs: [
+        makeTab({ id: 'tab-1', title: 'Tab 1' }),
+        makeTab({ id: 'tab-2', title: 'Tab 2' }),
+      ],
+      activeTabId: 'tab-1',
+      staticInfo: {
+        version: '1.0.0',
+        email: 'user@example.com',
+        subscriptionType: 'pro',
+        projectPath: 'C:/repo',
+        homePath: 'C:/Users/test',
+      },
+    })
+  })
+
+  it('setComposeDraft stores per-tab draft', () => {
+    useSessionStore.getState().setComposeDraft('tab-1', 'draft for tab 1')
+    expect(useSessionStore.getState().composeDrafts['tab-1']).toBe('draft for tab 1')
+  })
+
+  it('clearComposeDraft removes the draft', () => {
+    useSessionStore.getState().setComposeDraft('tab-1', 'draft')
+    useSessionStore.getState().clearComposeDraft('tab-1')
+    expect(useSessionStore.getState().composeDrafts['tab-1']).toBeUndefined()
+  })
+
+  it('drafts are independent per tab', () => {
+    useSessionStore.getState().setComposeDraft('tab-1', 'draft A')
+    useSessionStore.getState().setComposeDraft('tab-2', 'draft B')
+    expect(useSessionStore.getState().composeDrafts['tab-1']).toBe('draft A')
+    expect(useSessionStore.getState().composeDrafts['tab-2']).toBe('draft B')
+  })
+
+  it('closeTab cleans up the compose draft', () => {
+    // Ensure closeTab IPC mock is available
+    window.clui = {
+      ...window.clui,
+      closeTab: vi.fn().mockResolvedValue(undefined),
+    } as typeof window.clui
+    useSessionStore.getState().setComposeDraft('tab-1', 'draft')
+    useSessionStore.getState().closeTab('tab-1')
+    expect(useSessionStore.getState().composeDrafts['tab-1']).toBeUndefined()
+  })
+})
+
+describe('InputBar Ctrl+G integration', () => {
+  beforeEach(() => {
+    resetTestState()
+    useSessionStore.setState({
+      tabs: [makeTab({ id: 'tab-1', title: 'Chat' })],
+      activeTabId: 'tab-1',
+      staticInfo: {
+        version: '1.0.0',
+        email: 'user@example.com',
+        subscriptionType: 'pro',
+        projectPath: 'C:/repo',
+        homePath: 'C:/Users/test',
+      },
+    })
+  })
+
+  it('Ctrl+G opens compose editor', () => {
+    renderWithProviders(<InputBar />)
+    expect(screen.queryByTestId('compose-editor')).not.toBeInTheDocument()
+
+    fireEvent.keyDown(window, { key: 'g', ctrlKey: true })
+    expect(screen.getByTestId('compose-editor')).toBeInTheDocument()
+  })
+
+  it('Ctrl+G toggles compose editor closed when already open', () => {
+    renderWithProviders(<InputBar />)
+
+    fireEvent.keyDown(window, { key: 'g', ctrlKey: true })
+    expect(screen.getByTestId('compose-editor')).toBeInTheDocument()
+
+    fireEvent.keyDown(window, { key: 'g', ctrlKey: true })
+    expect(screen.queryByTestId('compose-editor')).not.toBeInTheDocument()
+  })
+})

--- a/tests/unit/keyboard-shortcuts.test.ts
+++ b/tests/unit/keyboard-shortcuts.test.ts
@@ -74,6 +74,14 @@ describe('keyboard shortcuts', () => {
     } as KeyboardEvent, false)).toBe('Alt+Shift+Left')
   })
 
+  it('includes compose-editor shortcut as Ctrl+G / Cmd+G', () => {
+    const windowsBindings = getDefaultShortcutBindings(false)
+    const macBindings = getDefaultShortcutBindings(true)
+
+    expect(windowsBindings.find((b) => b.id === 'compose-editor')?.currentKeys).toBe('Ctrl+G')
+    expect(macBindings.find((b) => b.id === 'compose-editor')?.currentKeys).toBe('Cmd+G')
+  })
+
   it('detects shortcut conflicts', () => {
     const bindings = getDefaultShortcutBindings(false)
     const conflict = findShortcutConflict(bindings, 'next-tab', 'Ctrl+Shift+Tab')


### PR DESCRIPTION
## Summary
- Full-height compose editor overlay for drafting complex multi-paragraph prompts
- Opens via `Ctrl+G` (Windows) / `Cmd+G` (macOS)
- Native editor inside pill UI (NOT `$EDITOR` spawn)
- Differentiates from `Ctrl+E` (inline expand) — this is a full compose experience

## Changes

### New Files
- `src/renderer/components/ComposeEditor.tsx` — Monospaced editor with line numbers, char/line counts, Framer Motion animation, all colors via `useColors()`, Phosphor icons
- `tests/renderer/components/ComposeEditor.test.tsx` — 18 tests

### Modified Files
- `src/shared/keyboard-shortcuts.ts` — Added `compose-editor` shortcut
- `src/renderer/components/InputBar.tsx` — Ctrl+G handler, compose submit/cancel, draft sync
- `src/renderer/stores/sessionStore.impl.ts` — Per-tab draft persistence (`composeDrafts`)

## Key Design Decisions
- Draft state in sessionStore (not component-local) — survives tab switches
- Compose closes on tab switch, draft preserved
- `initialText` precedence: stored draft > current input text
- No new IPC channels — pure renderer feature

## Test Plan
- [x] 18 unit tests covering render/hide, draft persistence, submit/cancel, keyboard shortcuts
- [ ] Manual: `Ctrl+G` opens editor, `Esc` closes without submit, `Ctrl+Enter` submits
- [ ] Manual: Draft preserved across tab switches
- [ ] `npm run build` passes
- [ ] `npm run test` passes

Closes #175