### PR TITLE
CLUI-CLI-004: Add multi-agent orchestration with --agent and --agents

### DIFF
--- a/src/main/claude/agent-args.ts
+++ b/src/main/claude/agent-args.ts
@@ -1,0 +1,63 @@
+/**
+ * Agent argument builder for CLI subprocess spawning.
+ *
+ * Translates RunOptions agent fields into CLI flags:
+ *   - `options.agent` → `--agent <name>` (pre-configured agent)
+ *   - `options.agentConfig` → `--agents '<json>'` (custom inline agents)
+ *
+ * Named agents take precedence over inline config when both are set.
+ */
+
+import type { AgentConfig, RunOptions } from '../../shared/types'
+
+/** Maximum agent tabs per parent group (backpressure) */
+export const MAX_AGENT_TABS_PER_GROUP = 5
+
+/**
+ * Build CLI args for agent mode.
+ * Returns empty array if no agent options are set.
+ */
+export function buildAgentArgs(options: RunOptions): string[] {
+  // Named agent takes precedence — simpler CLI invocation, avoids JSON on command line
+  if (options.agent) {
+    return ['--agent', options.agent]
+  }
+
+  if (options.agentConfig && Object.keys(options.agentConfig).length > 0) {
+    // Serialize to compact JSON for --agents flag
+    const json = JSON.stringify(options.agentConfig)
+    return ['--agents', json]
+  }
+
+  return []
+}
+
+/**
+ * Parse output from `claude agents` (or `claude agents --json`).
+ * Returns an array of AgentConfig objects.
+ *
+ * Handles:
+ *  - JSON array output
+ *  - Empty/whitespace output
+ *  - Non-JSON output (e.g. "No agents configured")
+ *  - Filters entries missing a `name` field
+ */
+export function parseAgentListOutput(stdout: string): AgentConfig[] {
+  const trimmed = stdout.trim()
+  if (!trimmed) return []
+
+  try {
+    const parsed = JSON.parse(trimmed)
+    if (!Array.isArray(parsed)) return []
+
+    return parsed.filter(
+      (entry: unknown): entry is AgentConfig =>
+        typeof entry === 'object' &&
+        entry !== null &&
+        typeof (entry as AgentConfig).name === 'string' &&
+        (entry as AgentConfig).name.length > 0,
+    )
+  } catch {
+    return []
+  }
+}

--- a/src/main/claude/control-plane.ts
+++ b/src/main/claude/control-plane.ts
@@ -954,6 +954,71 @@ export class ControlPlane extends EventEmitter {
     return { newTabId }
   }
 
+  // ─── Agent Tab ───
+
+  /**
+   * Create a new tab configured as an agent tab.
+   * The tab will spawn a CLI process with --agent or --agents flags.
+   */
+  async createAgentTab(
+    parentTabId: string,
+    agentName: string,
+    projectPath: string,
+    prompt: string,
+    agentConfig?: Record<string, import('../../shared/types').AgentConfig>,
+  ): Promise<{ tabId: string }> {
+    const parentTab = this.tabs.get(parentTabId)
+    if (!parentTab) throw new Error('Parent tab not found')
+
+    // Enforce max agent tabs per group
+    const { MAX_AGENT_TABS_PER_GROUP } = await import('./agent-args')
+    let agentCount = 0
+    for (const [, tab] of this.tabs) {
+      // Count tabs that share the same parentTabId (or are parented by parentTabId)
+      if ((tab as unknown as { parentTabId?: string }).parentTabId === parentTabId) {
+        agentCount++
+      }
+    }
+    if (agentCount >= MAX_AGENT_TABS_PER_GROUP) {
+      throw new Error(`Maximum ${MAX_AGENT_TABS_PER_GROUP} agent tabs per group`)
+    }
+
+    const tabId = this.createTab()
+    log(`Agent tab created: ${tabId} (agent=${agentName}, parent=${parentTabId})`)
+
+    const requestId = `agent-${tabId}`
+    const runOptions: import('../../shared/types').RunOptions = {
+      prompt,
+      projectPath,
+      ...(agentConfig ? { agentConfig } : { agent: agentName }),
+    }
+
+    await this.submitPrompt(tabId, requestId, runOptions)
+    return { tabId }
+  }
+
+  /**
+   * List available agents by running `claude agents --json`.
+   * Returns parsed AgentConfig array (may be empty if no agents configured).
+   */
+  async listAvailableAgents(): Promise<import('../../shared/types').AgentConfig[]> {
+    const { execSync } = await import('child_process')
+    const { parseAgentListOutput } = await import('./agent-args')
+    const { resolveClaudeEntryPoint } = await import('../platform')
+    const entry = resolveClaudeEntryPoint()
+
+    try {
+      const cmd = entry.prefixArgs.length > 0
+        ? `${entry.binary} ${entry.prefixArgs.join(' ')} agents --json`
+        : `${entry.binary} agents --json`
+      const stdout = execSync(cmd, { encoding: 'utf-8', timeout: 10000 }).trim()
+      return parseAgentListOutput(stdout)
+    } catch (err) {
+      log(`Failed to list agents: ${(err as Error).message}`)
+      return []
+    }
+  }
+
   // ─── Permission Response ───
 
   respondToPermission(tabId: string, questionId: string, optionId: string): boolean {

--- a/src/main/claude/run-manager.ts
+++ b/src/main/claude/run-manager.ts
@@ -8,6 +8,7 @@ import { resolveClaudeEntryPoint, getLoginShellPath, ensureBinDirInPath } from '
 import { spawnInWsl } from '../wsl/wsl-spawner'
 import { CircularBuffer } from '../circular-buffer'
 import { buildPromptArgs, cleanupPromptFile } from './prompt-file'
+import { buildAgentArgs } from './agent-args'
 import type { ClaudeEntryPoint } from '../platform'
 import type { ClaudeEvent, NormalizedEvent, RunOptions, EnrichedError } from '../../shared/types'
 
@@ -136,6 +137,12 @@ export class RunManager extends EventEmitter {
 
     if (options.effort) {
       args.push('--effort', options.effort)
+    }
+
+    // Agent mode: --agent <name> or --agents '<json>'
+    const agentArgs = buildAgentArgs(options)
+    if (agentArgs.length > 0) {
+      args.push(...agentArgs)
     }
 
     if (options.hookSettingsPath) {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -380,6 +380,19 @@ ipcMain.handle(IPC.FORK_SESSION, async (_event, { tabId, projectPath }: { tabId:
   return controlPlane.forkSession(tabId, projectPath)
 })
 
+ipcMain.handle(IPC.CREATE_AGENT_TAB, async (_event, { parentTabId, agentName, projectPath, prompt, agentConfig }: {
+  parentTabId: string; agentName: string; projectPath: string; prompt: string;
+  agentConfig?: Record<string, import('../shared/types').AgentConfig>
+}) => {
+  log(`IPC CREATE_AGENT_TAB: parent=${parentTabId} agent=${agentName}`)
+  return controlPlane.createAgentTab(parentTabId, agentName, projectPath, prompt, agentConfig)
+})
+
+ipcMain.handle(IPC.LIST_AGENTS, async () => {
+  log('IPC LIST_AGENTS')
+  return controlPlane.listAvailableAgents()
+})
+
 ipcMain.on(IPC.INIT_SESSION, (_event, tabId: string) => {
   log(`IPC INIT_SESSION: ${tabId}`)
   controlPlane.initSession(tabId)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -57,6 +57,8 @@ export interface CluiAPI {
   getDiagnostics(): Promise<any>
   respondPermission(tabId: string, questionId: string, optionId: string): Promise<boolean>
   forkSession(tabId: string, projectPath: string): Promise<{ newTabId: string }>
+  createAgentTab(parentTabId: string, agentName: string, projectPath: string, prompt: string, agentConfig?: Record<string, import('../shared/types').AgentConfig>): Promise<{ tabId: string }>
+  listAgents(): Promise<import('../shared/types').AgentConfig[]>
   initSession(tabId: string): void
   resetTabSession(tabId: string): void
   listSessions(projectPath?: string): Promise<SessionMeta[]>
@@ -182,6 +184,9 @@ const api: CluiAPI = {
   respondPermission: (tabId, questionId, optionId) =>
     ipcRenderer.invoke(IPC.RESPOND_PERMISSION, { tabId, questionId, optionId }),
   forkSession: (tabId, projectPath) => ipcRenderer.invoke(IPC.FORK_SESSION, { tabId, projectPath }),
+  createAgentTab: (parentTabId, agentName, projectPath, prompt, agentConfig) =>
+    ipcRenderer.invoke(IPC.CREATE_AGENT_TAB, { parentTabId, agentName, projectPath, prompt, agentConfig }),
+  listAgents: () => ipcRenderer.invoke(IPC.LIST_AGENTS),
   initSession: (tabId) => ipcRenderer.send(IPC.INIT_SESSION, tabId),
   resetTabSession: (tabId) => ipcRenderer.send(IPC.RESET_TAB_SESSION, tabId),
   listSessions: (projectPath?: string) => ipcRenderer.invoke(IPC.LIST_SESSIONS, projectPath),

--- a/src/renderer/components/InputBar.tsx
+++ b/src/renderer/components/InputBar.tsx
@@ -416,6 +416,22 @@ export function InputBar() {
           })
         break
       }
+      case '/agents': {
+        addSystemMessage('Fetching available agents...')
+        window.clui.listAgents()
+          .then((agents) => {
+            if (agents.length === 0) {
+              addSystemMessage('No agents configured. Use /agent <name> [prompt] to create a custom agent tab.')
+            } else {
+              const lines = agents.map((a) => `- **${a.name}**${a.description ? `: ${a.description}` : ''}`)
+              addSystemMessage(`Available agents (${agents.length}):\n${lines.join('\n')}\n\nUse: /agent <name> [prompt]`)
+            }
+          })
+          .catch((err: Error) => {
+            addSystemMessage(`Failed to list agents: ${err.message}`)
+          })
+        break
+      }
       case '/help': {
         const lines = [
           '/clear — Clear conversation history',
@@ -428,6 +444,8 @@ export function InputBar() {
           '/skills — Show available skills',
           '/workflow — Open workflow manager',
           '/fork — Fork this session into a new tab',
+          '/agent — Create a new agent tab',
+          '/agents — List available CLI agents',
           '/help — Show this list',
           '',
           '!<command> — Run shell command inline (e.g. !git status)',
@@ -635,6 +653,25 @@ export function InputBar() {
         clearComposer()
         addSystemMessage(`Unknown effort level "${effortMatch[1]}". Valid: low, medium, high, max, auto`)
       }
+      return
+    }
+
+    const agentMatch = prompt.match(/^\/agent\s+(\S+)(?:\s+(.+))?$/i)
+    if (agentMatch) {
+      clearComposer()
+      const agentName = agentMatch[1]
+      const agentPrompt = agentMatch[2]?.trim() || `You are the ${agentName} agent. Proceed with the task.`
+      const projectPath = tab?.hasChosenDirectory
+        ? tab.workingDirectory
+        : (staticInfo?.homePath || tab?.workingDirectory || '~')
+      addSystemMessage(`Creating agent tab: ${agentName}...`)
+      window.clui.createAgentTab(activeTabId, agentName, projectPath, agentPrompt)
+        .then(({ tabId: newTabId }) => {
+          useSessionStore.getState().agentTabCreated(newTabId, activeTabId, agentName, tab?.workingDirectory || '~')
+        })
+        .catch((err: Error) => {
+          addSystemMessage(`Agent tab failed: ${err.message}`)
+        })
       return
     }
 

--- a/src/renderer/components/SlashCommandMenu.tsx
+++ b/src/renderer/components/SlashCommandMenu.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from 'react'
 import { createPortal } from 'react-dom'
 import { motion } from 'framer-motion'
 import {
-  Trash, Cpu, CurrencyDollar, Question, HardDrives, Sparkle, Export, Columns, ListChecks, Gauge, GitFork,
+  Trash, Cpu, CurrencyDollar, Question, HardDrives, Sparkle, Export, Columns, ListChecks, Gauge, GitFork, Robot,
 } from '@phosphor-icons/react'
 import { usePopoverLayer } from './PopoverLayer'
 import { useColors } from '../theme'
@@ -32,6 +32,8 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { command: '/workflow', description: 'Open workflow manager', icon: <ListChecks size={13} /> },
   { command: '/effort', description: 'Set effort level: low|medium|high|max|auto', icon: <Gauge size={13} /> },
   { command: '/fork', description: 'Fork this session into a new tab', icon: <GitFork size={13} /> },
+  { command: '/agent', description: 'Create a new agent tab: /agent <name> [prompt]', icon: <Robot size={13} />, insertOnly: true },
+  { command: '/agents', description: 'List available CLI agents', icon: <Robot size={13} /> },
   { command: '/help', description: 'Show available commands', icon: <Question size={13} /> },
 ]
 

--- a/src/renderer/stores/sessionStore.impl.ts
+++ b/src/renderer/stores/sessionStore.impl.ts
@@ -125,6 +125,7 @@ export interface State {
   retryTab: (tabId: string) => void
   stopRetrying: (tabId: string) => void
   forkTabCreated: (newTabId: string, sourceTabId: string, parentTitle: string, workingDirectory: string, parentSessionId: string) => void
+  agentTabCreated: (newTabId: string, parentTabId: string, agentName: string, workingDirectory: string) => void
   handleNormalizedEvent: (tabId: string, event: NormalizedEvent) => void
   handleStatusChange: (tabId: string, newStatus: string, oldStatus: string) => void
   handleError: (tabId: string, error: EnrichedError) => void
@@ -385,6 +386,29 @@ export const useSessionStore = create<State>((set, get) => ({
       workingDirectory,
       hasChosenDirectory: true,
       parentSessionId,
+    }
+    set((s) => ({
+      tabs: orderTabsByTabOrder([...s.tabs, tab], [...s.tabOrder, tab.id]),
+      tabOrder: reconcileTabOrder([...s.tabOrder, tab.id], [...s.tabs, tab]),
+      activeTabId: tab.id,
+    }))
+    saveStoredTabOrder(get().tabOrder)
+  },
+
+  agentTabCreated: (newTabId, parentTabId, agentName, workingDirectory) => {
+    const tab: TabState = {
+      ...makeLocalTab(),
+      id: newTabId,
+      title: `Agent: ${agentName}`,
+      workingDirectory,
+      hasChosenDirectory: true,
+      agentName,
+      parentTabId,
+    }
+    // Find parent tab's group and assign agent tab to same group
+    const parentTab = get().tabs.find((t) => t.id === parentTabId)
+    if (parentTab?.groupId) {
+      tab.groupId = parentTab.groupId
     }
     set((s) => ({
       tabs: orderTabsByTabOrder([...s.tabs, tab], [...s.tabOrder, tab.id]),

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -172,6 +172,16 @@ export type AgentMemoryClaimResult =
   | { ok: true; snapshot: AgentMemorySnapshot; assignment: AgentAssignment }
   | { ok: false; snapshot: AgentMemorySnapshot; conflict: AgentAssignment }
 
+// ─── Agent Configuration ───
+
+export interface AgentConfig {
+  name: string
+  description?: string
+  prompt?: string
+  model?: string
+  tools?: string[]
+}
+
 export interface Attachment {
   id: string
   type: 'image' | 'file'
@@ -246,6 +256,10 @@ export interface TabState {
   contextNotificationShown: boolean
   /** Session ID of the parent session this tab was forked from */
   parentSessionId?: string
+  /** Agent name when this tab is an agent tab */
+  agentName?: string
+  /** Parent tab ID for agent tab grouping */
+  parentTabId?: string
 }
 
 export interface Message {
@@ -368,6 +382,10 @@ export interface RunOptions {
   forkSession?: boolean
   /** Session ID to fork from (used with forkSession) */
   forkFromSessionId?: string
+  /** Pre-configured agent name (passed as --agent <name>) */
+  agent?: string
+  /** Custom inline agent definitions (passed as --agents '<json>') */
+  agentConfig?: Record<string, AgentConfig>
 }
 
 // ─── Control Plane Types ───
@@ -581,6 +599,8 @@ export const IPC = {
   PIN_SESSION: 'clui:pin-session',
   UNPIN_SESSION: 'clui:unpin-session',
   FORK_SESSION: 'clui:fork-session',
+  CREATE_AGENT_TAB: 'clui:create-agent-tab',
+  LIST_AGENTS: 'clui:list-agents',
   SHELL_EXEC: 'clui:shell-exec',
 
   // One-way events (main → renderer)

--- a/tests/unit/multi-agent.test.ts
+++ b/tests/unit/multi-agent.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it, beforeEach } from 'vitest'
+import type { AgentConfig, RunOptions, TabState } from '../../src/shared/types'
+
+// ─── Test: AgentConfig type shape ───
+
+describe('AgentConfig type', () => {
+  it('accepts a named agent config', () => {
+    const config: AgentConfig = {
+      name: 'code-reviewer',
+      description: 'Reviews code changes',
+      prompt: 'You are a code review specialist.',
+      model: 'claude-sonnet-4-6',
+      tools: ['Read', 'Grep', 'Glob'],
+    }
+    expect(config.name).toBe('code-reviewer')
+    expect(config.description).toBe('Reviews code changes')
+  })
+
+  it('accepts a minimal agent config (name only)', () => {
+    const config: AgentConfig = { name: 'planner' }
+    expect(config.name).toBe('planner')
+    expect(config.description).toBeUndefined()
+    expect(config.prompt).toBeUndefined()
+    expect(config.model).toBeUndefined()
+    expect(config.tools).toBeUndefined()
+  })
+})
+
+// ─── Test: RunOptions agent fields ───
+
+describe('RunOptions agent fields', () => {
+  it('supports agent name for pre-configured agents', () => {
+    const opts: RunOptions = {
+      prompt: 'review this PR',
+      projectPath: '/tmp/project',
+      agent: 'code-reviewer',
+    }
+    expect(opts.agent).toBe('code-reviewer')
+  })
+
+  it('supports agentConfig for custom inline agents', () => {
+    const opts: RunOptions = {
+      prompt: 'review this PR',
+      projectPath: '/tmp/project',
+      agentConfig: {
+        reviewer: {
+          name: 'reviewer',
+          description: 'Reviews PRs',
+          prompt: 'You review code.',
+        },
+      },
+    }
+    expect(opts.agentConfig).toBeDefined()
+    expect(opts.agentConfig!['reviewer'].name).toBe('reviewer')
+  })
+})
+
+// ─── Test: TabState agent fields ───
+
+describe('TabState agent fields', () => {
+  it('supports agentName on TabState', () => {
+    const tab = {
+      agentName: 'code-reviewer',
+    } as Partial<TabState>
+    expect(tab.agentName).toBe('code-reviewer')
+  })
+
+  it('supports parentTabId on TabState', () => {
+    const tab = {
+      parentTabId: 'parent-tab-123',
+    } as Partial<TabState>
+    expect(tab.parentTabId).toBe('parent-tab-123')
+  })
+})
+
+// ─── Test: buildAgentArgs utility ───
+
+describe('buildAgentArgs', () => {
+  let buildAgentArgs: (options: RunOptions) => string[]
+
+  beforeEach(async () => {
+    const mod = await import('../../src/main/claude/agent-args')
+    buildAgentArgs = mod.buildAgentArgs
+  })
+
+  it('returns empty array when no agent options set', () => {
+    const args = buildAgentArgs({ prompt: 'hello', projectPath: '/tmp' })
+    expect(args).toEqual([])
+  })
+
+  it('returns --agent <name> when agent name is provided', () => {
+    const args = buildAgentArgs({
+      prompt: 'hello',
+      projectPath: '/tmp',
+      agent: 'code-reviewer',
+    })
+    expect(args).toEqual(['--agent', 'code-reviewer'])
+  })
+
+  it('returns --agents <json> when agentConfig is provided', () => {
+    const config: Record<string, AgentConfig> = {
+      reviewer: {
+        name: 'reviewer',
+        description: 'Reviews code',
+        prompt: 'You review code.',
+      },
+    }
+    const args = buildAgentArgs({
+      prompt: 'hello',
+      projectPath: '/tmp',
+      agentConfig: config,
+    })
+    expect(args).toHaveLength(2)
+    expect(args[0]).toBe('--agents')
+    const parsed = JSON.parse(args[1])
+    expect(parsed).toHaveProperty('reviewer')
+    expect(parsed.reviewer.description).toBe('Reviews code')
+  })
+
+  it('prefers agent over agentConfig when both provided', () => {
+    const args = buildAgentArgs({
+      prompt: 'hello',
+      projectPath: '/tmp',
+      agent: 'code-reviewer',
+      agentConfig: {
+        reviewer: { name: 'reviewer', description: 'Reviews code' },
+      },
+    })
+    // Named agent takes precedence
+    expect(args).toEqual(['--agent', 'code-reviewer'])
+  })
+})
+
+// ─── Test: Agent tab grouping limits ───
+
+describe('agent tab grouping', () => {
+  it('MAX_AGENT_TABS_PER_GROUP is 5', async () => {
+    const { MAX_AGENT_TABS_PER_GROUP } = await import('../../src/main/claude/agent-args')
+    expect(MAX_AGENT_TABS_PER_GROUP).toBe(5)
+  })
+})
+
+// ─── Test: parseAgentListOutput ───
+
+describe('parseAgentListOutput', () => {
+  let parseAgentListOutput: (stdout: string) => AgentConfig[]
+
+  beforeEach(async () => {
+    const mod = await import('../../src/main/claude/agent-args')
+    parseAgentListOutput = mod.parseAgentListOutput
+  })
+
+  it('parses JSON array output from claude agents', () => {
+    const stdout = JSON.stringify([
+      { name: 'code-reviewer', description: 'Reviews code changes' },
+      { name: 'planner', description: 'Plans tasks' },
+    ])
+    const agents = parseAgentListOutput(stdout)
+    expect(agents).toHaveLength(2)
+    expect(agents[0].name).toBe('code-reviewer')
+    expect(agents[1].name).toBe('planner')
+  })
+
+  it('returns empty array for empty output', () => {
+    expect(parseAgentListOutput('')).toEqual([])
+    expect(parseAgentListOutput('  ')).toEqual([])
+  })
+
+  it('returns empty array for non-JSON output', () => {
+    expect(parseAgentListOutput('No agents configured')).toEqual([])
+  })
+
+  it('returns empty array for JSON that is not an array', () => {
+    expect(parseAgentListOutput('{"name": "test"}')).toEqual([])
+  })
+
+  it('filters out entries without a name field', () => {
+    const stdout = JSON.stringify([
+      { name: 'valid', description: 'ok' },
+      { description: 'no name' },
+      { name: '', description: 'empty name' },
+    ])
+    const agents = parseAgentListOutput(stdout)
+    expect(agents).toHaveLength(1)
+    expect(agents[0].name).toBe('valid')
+  })
+})


### PR DESCRIPTION
## Summary
- Spawn and manage Claude CLI subagents from Clui CC tabs
- `/agent <name> [prompt]` creates a new agent tab with `--agent <name>` flag
- `/agents` lists available pre-configured agents via `claude agents --json`
- Custom inline agent definitions via `--agents '<json>'`
- Agent tabs grouped under parent via tabGroupStore, max 5 per group

## Changes

### New Files
- `src/main/claude/agent-args.ts` — `buildAgentArgs()`, `parseAgentListOutput()`, MAX_AGENT_TABS_PER_GROUP
- `tests/unit/multi-agent.test.ts` — 16 tests

### Modified Files
- `src/shared/types.ts` — `AgentConfig`, `agent`/`agentConfig` on RunOptions, `agentName`/`parentTabId` on TabState, IPC channels
- `src/main/claude/run-manager.ts` — `--agent`/`--agents` flags
- `src/main/claude/control-plane.ts` — `createAgentTab()`, `listAvailableAgents()`
- `src/main/index.ts` — IPC handlers
- `src/preload/index.ts` — `createAgentTab()`, `listAgents()` bridge
- `src/renderer/components/SlashCommandMenu.tsx` — `/agent`, `/agents` commands
- `src/renderer/components/InputBar.tsx` — Command handlers
- `src/renderer/stores/sessionStore.impl.ts` — `agentTabCreated()` action

## Test Plan
- [x] 16 unit tests (args builder, agent list parser, types)
- [ ] Manual: `/agents` lists available agents
- [ ] Manual: `/agent test-engineer "Write tests"` creates agent tab
- [ ] `npm run build` passes
- [ ] `npm run test` passes

Closes #174