### PR TITLE
UX-001: Add CodeBlock with shiki syntax highlighting

### DIFF
--- a/src/renderer/components/CodeBlock.tsx
+++ b/src/renderer/components/CodeBlock.tsx
@@ -1,0 +1,109 @@
+import React, { useState, useEffect } from 'react'
+import { motion } from 'framer-motion'
+import { Copy, Check } from '@phosphor-icons/react'
+import { useColors, useThemeStore } from '../theme'
+import { highlightCode } from '../utils/shiki'
+
+/** Copy button scoped to code blocks — lighter than the message-level CopyButton. */
+function CopyCodeButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false)
+  const colors = useColors()
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(text)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    } catch (err) {
+      console.warn('[CodeBlock] clipboard write failed:', err)
+    }
+  }
+
+  return (
+    <motion.button
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: 0.12 }}
+      onClick={handleCopy}
+      className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md text-[11px] cursor-pointer flex-shrink-0"
+      style={{
+        background: copied ? colors.statusCompleteBg : 'transparent',
+        color: copied ? colors.statusComplete : colors.textTertiary,
+        border: 'none',
+      }}
+      title="Copy code"
+    >
+      {copied ? <Check size={12} /> : <Copy size={12} />}
+      {copied ? 'Copied' : 'Copy'}
+    </motion.button>
+  )
+}
+
+/**
+ * Syntax-highlighted code block using shiki.
+ *
+ * Renders plain text immediately, then swaps in highlighted HTML once shiki resolves.
+ * Handles theme changes reactively via useThemeStore.
+ */
+export function CodeBlock({ code, language }: { code: string; language: string }) {
+  const [html, setHtml] = useState<string | null>(null)
+  const isDark = useThemeStore((s) => s.isDark)
+  const colors = useColors()
+
+  useEffect(() => {
+    let cancelled = false
+    setHtml(null)
+
+    highlightCode(code, language || 'plaintext', isDark)
+      .then((result) => {
+        if (!cancelled) setHtml(result)
+      })
+      .catch((err) => {
+        console.warn('[CodeBlock] shiki highlight failed:', err)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [code, language, isDark])
+
+  return (
+    <div
+      className="relative group/code rounded-lg overflow-hidden my-2"
+      style={{
+        background: colors.codeBg,
+        border: `1px solid ${colors.containerBorder}`,
+      }}
+    >
+      {/* Header: language label + copy button */}
+      <div
+        className="flex justify-between items-center px-3 py-1.5 text-[11px]"
+        style={{
+          color: colors.textTertiary,
+          borderBottom: `1px solid ${colors.containerBorder}`,
+        }}
+      >
+        <span>{language || 'text'}</span>
+        <CopyCodeButton text={code} />
+      </div>
+
+      {/* Code content */}
+      <div className="overflow-x-auto px-3 py-2 text-[12px] leading-[1.5]">
+        {html ? (
+          <div
+            data-testid="codeblock-highlighted"
+            className="[&_pre]:!bg-transparent [&_pre]:!m-0 [&_pre]:!p-0 [&_code]:!bg-transparent [&_code]:!p-0"
+            dangerouslySetInnerHTML={{ __html: html }}
+          />
+        ) : (
+          <pre className="m-0 p-0 bg-transparent">
+            <code className="bg-transparent p-0" style={{ color: colors.textPrimary }}>
+              {code}
+            </code>
+          </pre>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/ConversationView.tsx
+++ b/src/renderer/components/ConversationView.tsx
@@ -15,6 +15,7 @@ import { DirectoryPicker } from './DirectoryPicker'
 import { ToolTimeline } from './ToolTimeline'
 import { ShellOutput } from './ShellOutput'
 import { ResumeBrief } from './ResumeBrief'
+import { CodeBlock } from './CodeBlock'
 import { useColors, useThemeStore } from '../theme'
 import { generateResumeBrief, RESUME_INACTIVITY_MS, CATCH_ME_UP_PROMPT } from '../../shared/session-resume'
 import type { ResumeBrief as ResumeBriefData } from '../../shared/session-resume'
@@ -636,11 +637,22 @@ const AssistantMessage = React.memo(function AssistantMessage({
 
   const markdownComponents = useMemo(() => ({
     table: ({ children }: any) => <TableScrollWrapper>{children}</TableScrollWrapper>,
-    code: ({ children, className }: any) => {
-      if (className) return <code className={className}>{children}</code>
+    // Strip default <pre> styling when CodeBlock handles its own wrapper
+    pre: ({ children }: any) => <>{children}</>,
+    code: ({ children, className, ...props }: any) => {
+      const match = /language-(\w+)/.exec(className || '')
+      const isBlock = match || props.node?.position?.start?.line !== props.node?.position?.end?.line
+
+      if (match || isBlock) {
+        const language = match ? match[1] : ''
+        const code = String(children).replace(/\n$/, '')
+        return <CodeBlock code={code} language={language} />
+      }
+
+      // Inline code — detect file paths
       const text = typeof children === 'string' ? children : String(children ?? '')
       if (isLikelyFilePath(text)) return <FilePath path={text} displayName={text} />
-      return <code>{children}</code>
+      return <code className={className}>{children}</code>
     },
     a: ({ href, children }: any) => (
       <button

--- a/tests/renderer/components/CodeBlock.test.tsx
+++ b/tests/renderer/components/CodeBlock.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+
+import React from 'react'
+import { render, screen, act } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock shiki before importing CodeBlock
+const mockHighlightCode = vi.fn()
+vi.mock('../../../src/renderer/utils/shiki', () => ({
+  highlightCode: (...args: unknown[]) => mockHighlightCode(...args),
+}))
+
+// Mock clipboard API
+Object.assign(navigator, {
+  clipboard: {
+    writeText: vi.fn().mockResolvedValue(undefined),
+  },
+})
+
+import { CodeBlock } from '../../../src/renderer/components/CodeBlock'
+
+describe('CodeBlock', () => {
+  beforeEach(() => {
+    mockHighlightCode.mockReset()
+    // Default: never resolves (simulates loading state)
+    mockHighlightCode.mockReturnValue(new Promise(() => {}))
+  })
+
+  it('renders plain code text as fallback before shiki loads', () => {
+    render(<CodeBlock code="const x = 1" language="typescript" />)
+
+    expect(screen.getByText('const x = 1')).toBeInTheDocument()
+    // Should be inside a <pre><code> fallback
+    const codeEl = screen.getByText('const x = 1')
+    expect(codeEl.tagName).toBe('CODE')
+    expect(codeEl.parentElement?.tagName).toBe('PRE')
+  })
+
+  it('displays the language label', () => {
+    render(<CodeBlock code="print('hi')" language="python" />)
+
+    expect(screen.getByText('python')).toBeInTheDocument()
+  })
+
+  it('displays "text" when no language is provided', () => {
+    render(<CodeBlock code="plain text" language="" />)
+
+    expect(screen.getByText('text')).toBeInTheDocument()
+  })
+
+  it('has a copy button', () => {
+    render(<CodeBlock code="copy me" language="bash" />)
+
+    const copyBtn = screen.getByTitle('Copy code')
+    expect(copyBtn).toBeInTheDocument()
+  })
+
+  it('calls highlightCode with correct language and isDark', () => {
+    render(<CodeBlock code="fn main() {}" language="rust" />)
+
+    expect(mockHighlightCode).toHaveBeenCalledWith('fn main() {}', 'rust', true)
+  })
+
+  it('renders highlighted HTML when shiki resolves', async () => {
+    const highlightedHtml = '<span class="line"><span style="color:#f97583">const</span> x = 1</span>'
+    mockHighlightCode.mockResolvedValue(highlightedHtml)
+
+    render(<CodeBlock code="const x = 1" language="typescript" />)
+
+    // Wait for the async highlight to resolve
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10))
+    })
+
+    // The highlighted HTML should be rendered via dangerouslySetInnerHTML
+    const highlighted = screen.getByTestId('codeblock-highlighted')
+    expect(highlighted.innerHTML).toContain('color:#f97583')
+  })
+
+  it('keeps showing plain text if highlightCode rejects', async () => {
+    mockHighlightCode.mockRejectedValue(new Error('shiki load failed'))
+
+    render(<CodeBlock code="fallback text" language="javascript" />)
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10))
+    })
+
+    // Fallback text should still be visible
+    expect(screen.getByText('fallback text')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- Connects shiki (already installed) to code blocks in assistant messages
- Language label, per-block copy button, horizontal scroll
- Async loading: plain text fallback → highlighted HTML when shiki loads

## Changes
- `src/renderer/components/CodeBlock.tsx` (NEW) — shiki-powered code block
- `src/renderer/components/ConversationView.tsx` — wire CodeBlock into markdown renderer
- `tests/renderer/components/CodeBlock.test.tsx` (NEW) — 7 tests

## Test Plan
- [x] 7 unit tests (fallback, language label, copy, highlighting, error handling)
- [ ] Manual: code blocks show syntax colors
- [ ] `npm run build` + `npm run test` pass

Closes #187