### PR TITLE
UX-002: Add visual distinction between user and assistant messages

### DIFF
--- a/src/renderer/components/ConversationView.tsx
+++ b/src/renderer/components/ConversationView.tsx
@@ -26,6 +26,9 @@ const INITIAL_RENDER_CAP = 100
 const PAGE_SIZE = 100
 const REMARK_PLUGINS = [remarkGfm] // Hoisted — prevents re-parse on every render
 
+/** Tailwind class for vertical spacing between grouped messages. Exported for testing. */
+export const MESSAGE_GAP_CLASS = 'space-y-5'
+
 // ─── Types ───
 
 type GroupedItem =
@@ -242,7 +245,7 @@ export function ConversationView({ overrideTabId }: { overrideTabId?: string } =
           )}
         </AnimatePresence>
 
-        <div className="space-y-1 relative">
+        <div className={`${MESSAGE_GAP_CLASS} relative`}>
           {grouped.map((item, idx) => {
             const msgIndex = startIndex + idx
             const isHistorical = msgIndex < historicalThreshold
@@ -455,7 +458,7 @@ const InterruptButton = React.memo(function InterruptButton({ tabId }: { tabId: 
 
 // ─── User Message (memoized — only re-renders when message reference changes) ───
 
-const UserMessage = React.memo(function UserMessage({ message, skipMotion }: { message: Message; skipMotion?: boolean }) {
+export const UserMessage = React.memo(function UserMessage({ message, skipMotion }: { message: Message; skipMotion?: boolean }) {
   const colors = useColors()
   const content = (
     <div
@@ -625,7 +628,7 @@ function ImageCard({ src, alt, colors }: { src?: string; alt?: string; colors: R
 
 // ─── Assistant Message (memoized — only re-renders when content changes) ───
 
-const AssistantMessage = React.memo(function AssistantMessage({
+export const AssistantMessage = React.memo(function AssistantMessage({
   message,
   skipMotion,
 }: {
@@ -658,7 +661,14 @@ const AssistantMessage = React.memo(function AssistantMessage({
   }), [colors])
 
   const inner = (
-    <div data-testid="message-assistant" className="group/msg relative">
+    <div
+      data-testid="message-assistant"
+      className="group/msg relative rounded-lg px-3 py-2"
+      style={{
+        background: colors.messageBgAssistant,
+        borderLeft: `3px solid ${colors.messageAccentBorder}`,
+      }}
+    >
       <div className="text-[13px] leading-[1.6] prose-cloud min-w-0 max-w-[92%]">
         <Markdown remarkPlugins={REMARK_PLUGINS} components={markdownComponents}>
           {message.content}
@@ -707,7 +717,7 @@ function tryParseShellOutput(content: string): ShellOutputType | null {
   return null
 }
 
-const SystemMessage = React.memo(function SystemMessage({ message, skipMotion }: { message: Message; skipMotion?: boolean }) {
+export const SystemMessage = React.memo(function SystemMessage({ message, skipMotion }: { message: Message; skipMotion?: boolean }) {
   const isError = message.content.startsWith('Error:') || message.content.includes('unexpectedly')
   const colors = useColors()
 
@@ -731,24 +741,25 @@ const SystemMessage = React.memo(function SystemMessage({ message, skipMotion }:
   const inner = (
     <div
       data-testid={isError ? 'message-system-error' : 'message-system'}
-      className="text-[11px] leading-[1.5] px-2.5 py-1 rounded-lg inline-block whitespace-pre-wrap"
+      className="text-xs leading-[1.5] px-2.5 py-1 rounded-lg inline-block whitespace-pre-wrap"
       style={{
         background: isError ? colors.statusErrorBg : colors.surfaceHover,
         color: isError ? colors.statusError : colors.textTertiary,
+        fontStyle: 'italic',
       }}
     >
       {message.content}
     </div>
   )
 
-  if (skipMotion) return <div className="py-0.5">{inner}</div>
+  if (skipMotion) return <div className="py-0.5 text-center">{inner}</div>
 
   return (
     <motion.div
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       transition={{ duration: 0.15 }}
-      className="py-0.5"
+      className="py-0.5 text-center"
     >
       {inner}
     </motion.div>

--- a/src/renderer/components/__tests__/message-distinction.test.tsx
+++ b/src/renderer/components/__tests__/message-distinction.test.tsx
@@ -1,0 +1,157 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeAll } from 'vitest'
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+
+// Mock theme module — return real-ish token values so style assertions work
+const mockColors: Record<string, string> = {
+  accent: '#d97757',
+  accentSoft: 'rgba(217, 119, 87, 0.15)',
+  userBubble: '#353530',
+  userBubbleBorder: '#4a4a45',
+  userBubbleText: '#ccc9c0',
+  containerBg: '#242422',
+  textPrimary: '#ccc9c0',
+  textSecondary: '#c0bdb2',
+  textTertiary: '#76766e',
+  surfaceHover: 'rgba(255, 255, 255, 0.05)',
+  surfacePrimary: '#353530',
+  toolBorder: '#4a4a45',
+  statusError: '#c47060',
+  statusErrorBg: 'rgba(196, 112, 96, 0.08)',
+  statusComplete: '#7aac8c',
+  statusCompleteBg: 'rgba(122, 172, 140, 0.1)',
+  statusRunning: '#d97757',
+  messageBgAssistant: 'rgba(217, 119, 87, 0.04)',
+  messageAccentBorder: '#d97757',
+}
+
+vi.mock('../../theme', () => ({
+  useColors: () => mockColors,
+  useThemeStore: (selector: any) => {
+    const state = { isDark: true, expandedUI: false }
+    return selector ? selector(state) : state
+  },
+}))
+
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: React.forwardRef(({ children, ...props }: any, ref: any) =>
+      React.createElement('div', { ...props, ref }, children),
+    ),
+    button: React.forwardRef(({ children, ...props }: any, ref: any) =>
+      React.createElement('button', { ...props, ref }, children),
+    ),
+  },
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => children,
+}))
+
+vi.mock('react-markdown', () => ({
+  default: ({ children }: { children: string }) =>
+    React.createElement('div', { 'data-testid': 'markdown' }, children),
+}))
+
+vi.mock('remark-gfm', () => ({ default: {} }))
+
+vi.mock('../../stores/sessionStore', () => ({
+  useSessionStore: Object.assign(
+    (selector: any) => {
+      const state = {
+        activeTabId: 'tab-1',
+        tabs: [],
+        sendMessage: vi.fn(),
+        staticInfo: null,
+      }
+      return selector ? selector(state) : state
+    },
+    { getState: () => ({ activeTabId: 'tab-1' }), setState: vi.fn() },
+  ),
+}))
+
+vi.mock('../FilePath', () => ({ FilePath: ({ path }: any) => React.createElement('span', null, path) }))
+vi.mock('../PermissionCard', () => ({ PermissionCard: () => null }))
+vi.mock('../PermissionDeniedCard', () => ({ PermissionDeniedCard: () => null }))
+vi.mock('../RetryBanner', () => ({ RetryBanner: () => null }))
+vi.mock('../DirectoryPicker', () => ({ DirectoryPicker: () => null }))
+vi.mock('../ToolTimeline', () => ({ ToolTimeline: () => null }))
+vi.mock('../ShellOutput', () => ({ ShellOutput: () => null }))
+vi.mock('../ResumeBrief', () => ({ ResumeBrief: () => null }))
+vi.mock('../../utils/file-path-detect', () => ({ isLikelyFilePath: () => false }))
+vi.mock('../../../shared/session-resume', () => ({
+  generateResumeBrief: () => null,
+  RESUME_INACTIVITY_MS: 300000,
+  CATCH_ME_UP_PROMPT: 'catch me up',
+}))
+
+import {
+  UserMessage,
+  AssistantMessage,
+  SystemMessage,
+  MESSAGE_GAP_CLASS,
+} from '../ConversationView'
+
+import type { Message } from '../../../shared/types'
+
+function makeMsg(overrides: Partial<Message> & { role: Message['role'] }): Message {
+  return {
+    id: `msg-${Math.random().toString(36).slice(2)}`,
+    content: 'test content',
+    timestamp: Date.now(),
+    ...overrides,
+  }
+}
+
+describe('Message visual distinction', () => {
+  describe('AssistantMessage', () => {
+    it('has a 3px left accent border', () => {
+      const msg = makeMsg({ role: 'assistant', content: 'Hello world' })
+      render(<AssistantMessage message={msg} skipMotion />)
+      const el = screen.getByTestId('message-assistant')
+      // jsdom normalizes hex to rgb(), so check for 3px solid + rgb values of #d97757
+      expect(el.style.borderLeft).toContain('3px solid')
+      expect(el.style.borderLeft).toContain('rgb(217, 119, 87)')
+    })
+
+    it('has assistant background color token', () => {
+      const msg = makeMsg({ role: 'assistant', content: 'Test reply' })
+      render(<AssistantMessage message={msg} skipMotion />)
+      const el = screen.getByTestId('message-assistant')
+      expect(el.style.background).toBe(mockColors.messageBgAssistant)
+    })
+  })
+
+  describe('UserMessage', () => {
+    it('has user bubble background distinct from assistant', () => {
+      const msg = makeMsg({ role: 'user', content: 'Hi there' })
+      render(<UserMessage message={msg} skipMotion />)
+      const el = screen.getByTestId('message-user')
+      // jsdom normalizes #353530 to rgb(53, 53, 48)
+      expect(el.style.background).toBe('rgb(53, 53, 48)')
+      // Token values must differ between user and assistant
+      expect(mockColors.userBubble).not.toBe(mockColors.messageBgAssistant)
+    })
+  })
+
+  describe('SystemMessage', () => {
+    it('uses muted smaller italic text with centered layout', () => {
+      const msg = makeMsg({ role: 'system', content: 'System notice' })
+      render(<SystemMessage message={msg} skipMotion />)
+      const el = screen.getByTestId('message-system')
+      expect(el.style.fontStyle).toBe('italic')
+      expect(el.className).toContain('text-xs')
+      const wrapper = el.parentElement!
+      expect(wrapper.className).toContain('text-center')
+    })
+  })
+
+  describe('Message gap', () => {
+    it('MESSAGE_GAP_CLASS provides at least 20px spacing (space-y-5 or larger)', () => {
+      const match = MESSAGE_GAP_CLASS.match(/space-y-(\d+)/)
+      expect(match).not.toBeNull()
+      const gapLevel = parseInt(match![1], 10)
+      expect(gapLevel).toBeGreaterThanOrEqual(5)
+    })
+  })
+})

--- a/src/renderer/theme.ts
+++ b/src/renderer/theme.ts
@@ -61,6 +61,10 @@ const darkColors = {
   userBubbleBorder: '#4a4a45',
   userBubbleText: '#ccc9c0',
 
+  // Assistant message
+  messageBgAssistant: 'rgba(217, 119, 87, 0.04)',
+  messageAccentBorder: '#d97757',
+
   // Tool card
   toolBg: '#353530',
   toolBorder: '#4a4a45',
@@ -216,6 +220,10 @@ const lightColors = {
   userBubble: '#edeae0',
   userBubbleBorder: '#dddad2',
   userBubbleText: '#3c3929',
+
+  // Assistant message
+  messageBgAssistant: 'rgba(217, 119, 87, 0.05)',
+  messageAccentBorder: '#d97757',
 
   // Tool card
   toolBg: '#edeae0',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
-    include: ['tests/**/*.test.ts', 'tests/**/*.test.tsx', 'src/**/__tests__/**/*.test.ts'],
+    include: ['tests/**/*.test.ts', 'tests/**/*.test.tsx', 'src/**/__tests__/**/*.test.ts', 'src/**/__tests__/**/*.test.tsx'],
     setupFiles: ['tests/setup.ts'],
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
## Summary
- Assistant messages: warm background tint + 3px accent left border
- System messages: italic, centered, text-xs
- Message gap increased from 4px to 20px

## Changes
- `src/renderer/theme.ts` — Added `messageBgAssistant`, `messageAccentBorder` tokens
- `src/renderer/components/ConversationView.tsx` — Styled messages, increased gap
- `tests/` — 5 tests for visual distinction

## Test Plan
- [x] 5 unit tests
- [ ] Manual: messages clearly distinguishable at a glance
- [ ] `npm run build` + `npm run test` pass

Closes #188