### PR TITLE
UX-003: Collapsible tool blocks with smart summaries

### DIFF
--- a/src/renderer/components/ToolBlockSummary.tsx
+++ b/src/renderer/components/ToolBlockSummary.tsx
@@ -1,0 +1,266 @@
+import React, { useState, useMemo } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+import {
+  Terminal, FileText, PencilSimple, MagnifyingGlass, Wrench,
+  CaretDown, CaretRight,
+} from '@phosphor-icons/react'
+import type { Icon } from '@phosphor-icons/react'
+import { useColors } from '../theme'
+
+// ─── Constants ───
+
+const AUTO_COLLAPSE_THRESHOLD = 15
+const PREVIEW_LINE_COUNT = 5
+
+// ─── Tool type classification ───
+
+interface ToolTypeInfo {
+  iconName: string
+  icon: Icon
+  category: 'bash' | 'read' | 'edit' | 'search' | 'other'
+}
+
+const TOOL_TYPE_MAP: Record<string, ToolTypeInfo> = {
+  Bash: { iconName: 'Terminal', icon: Terminal, category: 'bash' },
+  bash: { iconName: 'Terminal', icon: Terminal, category: 'bash' },
+  Read: { iconName: 'FileText', icon: FileText, category: 'read' },
+  file_read: { iconName: 'FileText', icon: FileText, category: 'read' },
+  Edit: { iconName: 'PencilSimple', icon: PencilSimple, category: 'edit' },
+  Write: { iconName: 'PencilSimple', icon: PencilSimple, category: 'edit' },
+  file_edit: { iconName: 'PencilSimple', icon: PencilSimple, category: 'edit' },
+  Search: { iconName: 'MagnifyingGlass', icon: MagnifyingGlass, category: 'search' },
+  Grep: { iconName: 'MagnifyingGlass', icon: MagnifyingGlass, category: 'search' },
+  Glob: { iconName: 'MagnifyingGlass', icon: MagnifyingGlass, category: 'search' },
+}
+
+const DEFAULT_TOOL_TYPE: ToolTypeInfo = {
+  iconName: 'Wrench',
+  icon: Wrench,
+  category: 'other',
+}
+
+export function getToolTypeInfo(toolName: string): ToolTypeInfo {
+  return TOOL_TYPE_MAP[toolName] ?? DEFAULT_TOOL_TYPE
+}
+
+// ─── Summary generation ───
+
+function basename(path: string): string {
+  const parts = path.replace(/\\/g, '/').split('/')
+  return parts[parts.length - 1] || path
+}
+
+function safeParse(input: string): Record<string, unknown> | null {
+  try {
+    const parsed: unknown = JSON.parse(input)
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>
+    }
+    return null
+  } catch {
+    return null
+  }
+}
+
+function countLines(text: string): number {
+  if (!text) return 0
+  return text.split('\n').length
+}
+
+export function getToolSummary(
+  toolName: string,
+  toolInput: string | undefined,
+  content: string,
+): string {
+  const info = getToolTypeInfo(toolName)
+  const parsed = toolInput ? safeParse(toolInput) : null
+
+  switch (info.category) {
+    case 'bash': {
+      const cmd = parsed?.command
+      const cmdStr = typeof cmd === 'string' ? cmd.trim() : ''
+      const shortCmd = cmdStr.length > 60 ? `${cmdStr.substring(0, 57)}...` : cmdStr
+      // Try to extract exit code from content
+      const exitMatch = content.match(/exit code[:\s]*(\d+)/i)
+      const exitStr = exitMatch ? ` (exit ${exitMatch[1]})` : ''
+      return shortCmd ? `$ ${shortCmd}${exitStr}` : `Bash${exitStr}`
+    }
+    case 'read': {
+      const fp = parsed?.file_path ?? parsed?.path
+      const name = typeof fp === 'string' ? basename(fp) : 'file'
+      const lines = countLines(content)
+      return `Read ${name} (${lines} lines)`
+    }
+    case 'edit': {
+      const fp = parsed?.file_path ?? ''
+      const name = typeof fp === 'string' ? basename(fp) : 'file'
+      const oldStr = typeof parsed?.old_string === 'string' ? parsed.old_string : ''
+      const newStr = typeof parsed?.new_string === 'string' ? parsed.new_string : (typeof parsed?.content === 'string' ? parsed.content : '')
+      const removed = oldStr ? oldStr.split('\n').length : 0
+      const added = newStr ? newStr.split('\n').length : 0
+      if (added > 0 || removed > 0) {
+        return `Edited ${name} (+${added} -${removed})`
+      }
+      return `Edited ${name}`
+    }
+    case 'search': {
+      const pattern = parsed?.pattern ?? ''
+      const patternStr = typeof pattern === 'string' ? pattern : ''
+      const resultLines = content ? content.split('\n').filter((l) => l.trim()).length : 0
+      const patternPart = patternStr ? `"${patternStr.length > 20 ? `${patternStr.substring(0, 17)}...` : patternStr}"` : ''
+      return `Search ${patternPart} (${resultLines} results)`
+    }
+    default:
+      return toolName
+  }
+}
+
+// ─── Collapse logic ───
+
+export function shouldAutoCollapse(content: string): boolean {
+  if (!content) return false
+  return content.split('\n').length > AUTO_COLLAPSE_THRESHOLD
+}
+
+export function getCollapsedPreviewLines(content: string): {
+  previewLines: string[]
+  remainingCount: number
+} {
+  const lines = content.split('\n')
+  if (lines.length <= PREVIEW_LINE_COUNT) {
+    return { previewLines: lines, remainingCount: 0 }
+  }
+  return {
+    previewLines: lines.slice(0, PREVIEW_LINE_COUNT),
+    remainingCount: lines.length - PREVIEW_LINE_COUNT,
+  }
+}
+
+// ─── CollapsibleToolOutput Component ───
+
+export interface CollapsibleToolOutputProps {
+  toolName: string
+  toolInput?: string
+  content: string
+  toolStatus?: 'running' | 'completed' | 'error'
+}
+
+export function CollapsibleToolOutput({
+  toolName,
+  toolInput,
+  content,
+  toolStatus,
+}: CollapsibleToolOutputProps) {
+  const colors = useColors()
+  const info = getToolTypeInfo(toolName)
+  const ToolIcon = info.icon
+
+  const summary = useMemo(
+    () => getToolSummary(toolName, toolInput, content),
+    [toolName, toolInput, content],
+  )
+
+  const autoCollapse = useMemo(() => shouldAutoCollapse(content), [content])
+  const [collapsed, setCollapsed] = useState(autoCollapse)
+
+  const preview = useMemo(
+    () => (collapsed ? getCollapsedPreviewLines(content) : null),
+    [collapsed, content],
+  )
+
+  const isError = toolStatus === 'error'
+
+  return (
+    <div
+      className="rounded-md overflow-hidden text-[12px] mt-1"
+      style={{
+        background: colors.codeBg,
+        border: `1px solid ${isError ? colors.statusError : colors.toolBorder}`,
+      }}
+    >
+      {/* Header: icon + summary */}
+      <div
+        data-testid="tool-block-header"
+        className="flex items-center gap-1.5 px-2 py-1 cursor-pointer select-none"
+        style={{
+          background: colors.surfaceHover,
+          borderBottom: `1px solid ${colors.toolBorder}`,
+          color: isError ? colors.statusError : colors.textSecondary,
+        }}
+        onClick={() => {
+          if (autoCollapse) setCollapsed((prev) => !prev)
+        }}
+      >
+        <ToolIcon size={12} />
+        <span className="truncate flex-1">{summary}</span>
+        {autoCollapse && (
+          collapsed
+            ? <CaretRight size={10} style={{ color: colors.textMuted }} />
+            : <CaretDown size={10} style={{ color: colors.textMuted }} />
+        )}
+      </div>
+
+      {/* Content area */}
+      {collapsed && preview ? (
+        <div className="px-2 py-1.5">
+          <pre
+            data-testid="tool-output-preview"
+            className="whitespace-pre-wrap break-all text-[11px] leading-[1.5] font-mono"
+            style={{ color: colors.textTertiary }}
+          >
+            {preview.previewLines.join('\n')}
+          </pre>
+          {preview.remainingCount > 0 && (
+            <button
+              data-testid="show-more-btn"
+              type="button"
+              className="mt-1 text-[11px] cursor-pointer rounded px-1.5 py-0.5 transition-colors"
+              style={{
+                color: colors.accent,
+                background: 'transparent',
+                border: 'none',
+              }}
+              onClick={() => setCollapsed(false)}
+            >
+              Show {preview.remainingCount} more lines
+            </button>
+          )}
+        </div>
+      ) : (
+        <AnimatePresence initial={false}>
+          <motion.div
+            key="full"
+            initial={autoCollapse ? { opacity: 0, height: 0 } : false}
+            animate={{ opacity: 1, height: 'auto' }}
+            exit={{ opacity: 0, height: 0 }}
+            transition={{ duration: 0.15 }}
+            className="px-2 py-1.5"
+          >
+            <pre
+              data-testid="tool-output-full"
+              className="whitespace-pre-wrap break-all text-[11px] leading-[1.5] font-mono"
+              style={{ color: colors.textTertiary }}
+            >
+              {content}
+            </pre>
+            {autoCollapse && (
+              <button
+                data-testid="show-less-btn"
+                type="button"
+                className="mt-1 text-[11px] cursor-pointer rounded px-1.5 py-0.5 transition-colors"
+                style={{
+                  color: colors.accent,
+                  background: 'transparent',
+                  border: 'none',
+                }}
+                onClick={() => setCollapsed(true)}
+              >
+                Show less
+              </button>
+            )}
+          </motion.div>
+        </AnimatePresence>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/components/ToolTimeline.tsx
+++ b/src/renderer/components/ToolTimeline.tsx
@@ -9,6 +9,7 @@ import {
 import { useColors } from '../theme'
 import { FilePath } from './FilePath'
 import { DiffViewer } from './DiffViewer'
+import { CollapsibleToolOutput } from './ToolBlockSummary'
 import type { Message } from '../../shared/types'
 
 // ─── Icon mapping ───
@@ -466,6 +467,10 @@ function ExpandedPillDetail({
   const toolName = tool.toolName || 'Tool'
   const desc = getToolDescription(toolName, tool.toolInput)
 
+  // Edit/Write tools get the DiffViewer via ToolDetail; all others get collapsible output
+  const showDiffViewer = (toolName === 'Edit' || toolName === 'Write') && tool.toolInput
+  const hasCollapsibleContent = !showDiffViewer && tool.content.trim().length > 0
+
   return (
     <motion.div
       initial={{ opacity: 0, height: 0 }}
@@ -488,7 +493,18 @@ function ExpandedPillDetail({
         >
           <ToolDescriptionWithFilePath desc={desc} toolInput={tool.toolInput} />
         </span>
-        <ToolDetail tool={tool} />
+        {showDiffViewer ? (
+          <ToolDetail tool={tool} />
+        ) : hasCollapsibleContent ? (
+          <CollapsibleToolOutput
+            toolName={toolName}
+            toolInput={tool.toolInput}
+            content={tool.content}
+            toolStatus={tool.toolStatus}
+          />
+        ) : (
+          <ToolDetail tool={tool} />
+        )}
       </div>
     </motion.div>
   )

--- a/src/renderer/components/__tests__/collapsible-tool-blocks.test.tsx
+++ b/src/renderer/components/__tests__/collapsible-tool-blocks.test.tsx
@@ -1,0 +1,339 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+// ─── Mocks ───
+
+const mockColors: Record<string, string> = {
+  accent: '#d97757',
+  accentSoft: 'rgba(217, 119, 87, 0.15)',
+  accentBorderMedium: 'rgba(217, 119, 87, 0.25)',
+  textPrimary: '#ccc9c0',
+  textSecondary: '#c0bdb2',
+  textTertiary: '#76766e',
+  textMuted: '#353530',
+  surfaceHover: 'rgba(255, 255, 255, 0.05)',
+  surfacePrimary: '#353530',
+  toolBg: '#353530',
+  toolBorder: '#4a4a45',
+  toolRunningBorder: 'rgba(217, 119, 87, 0.3)',
+  toolRunningBg: 'rgba(217, 119, 87, 0.05)',
+  statusError: '#c47060',
+  statusErrorBg: 'rgba(196, 112, 96, 0.08)',
+  statusComplete: '#7aac8c',
+  statusCompleteBg: 'rgba(122, 172, 140, 0.1)',
+  statusRunning: '#d97757',
+  timelineLine: '#353530',
+  codeBg: '#1a1a18',
+}
+
+vi.mock('../../theme', () => ({
+  useColors: () => mockColors,
+  useThemeStore: (selector: any) => {
+    const state = { isDark: true, expandedUI: false }
+    return selector ? selector(state) : state
+  },
+}))
+
+vi.mock('../FilePath', () => ({
+  FilePath: ({ path }: any) => React.createElement('span', null, path),
+}))
+
+vi.mock('../DiffViewer', () => ({
+  DiffViewer: () => React.createElement('div', { 'data-testid': 'diff-viewer' }),
+}))
+
+import type { Message } from '../../../shared/types'
+
+// ─── Import summary logic ───
+
+import {
+  getToolSummary,
+  shouldAutoCollapse,
+  getCollapsedPreviewLines,
+  getToolTypeInfo,
+} from '../ToolBlockSummary'
+
+// ─── Helper ───
+
+function makeToolMsg(overrides: Partial<Message> = {}): Message {
+  return {
+    id: `tool-${Math.random().toString(36).slice(2)}`,
+    role: 'tool',
+    content: '',
+    timestamp: Date.now(),
+    toolName: 'Bash',
+    toolStatus: 'completed',
+    ...overrides,
+  }
+}
+
+function makeLongContent(lineCount: number): string {
+  return Array.from({ length: lineCount }, (_, i) => `line ${i + 1}`).join('\n')
+}
+
+// ─── Tests ───
+
+describe('ToolBlockSummary', () => {
+  describe('getToolTypeInfo', () => {
+    it('returns Terminal icon name for Bash tool', () => {
+      const info = getToolTypeInfo('Bash')
+      expect(info.iconName).toBe('Terminal')
+    })
+
+    it('returns FileText icon name for Read tool', () => {
+      const info = getToolTypeInfo('Read')
+      expect(info.iconName).toBe('FileText')
+    })
+
+    it('returns FileText icon name for file_read tool', () => {
+      const info = getToolTypeInfo('file_read')
+      expect(info.iconName).toBe('FileText')
+    })
+
+    it('returns PencilSimple icon name for Edit tool', () => {
+      const info = getToolTypeInfo('Edit')
+      expect(info.iconName).toBe('PencilSimple')
+    })
+
+    it('returns PencilSimple icon name for Write tool', () => {
+      const info = getToolTypeInfo('Write')
+      expect(info.iconName).toBe('PencilSimple')
+    })
+
+    it('returns PencilSimple icon name for file_edit tool', () => {
+      const info = getToolTypeInfo('file_edit')
+      expect(info.iconName).toBe('PencilSimple')
+    })
+
+    it('returns MagnifyingGlass icon name for Grep tool', () => {
+      const info = getToolTypeInfo('Grep')
+      expect(info.iconName).toBe('MagnifyingGlass')
+    })
+
+    it('returns MagnifyingGlass icon name for Glob tool', () => {
+      const info = getToolTypeInfo('Glob')
+      expect(info.iconName).toBe('MagnifyingGlass')
+    })
+
+    it('returns MagnifyingGlass icon name for Search tool', () => {
+      const info = getToolTypeInfo('Search')
+      expect(info.iconName).toBe('MagnifyingGlass')
+    })
+  })
+
+  describe('getToolSummary', () => {
+    it('generates bash summary with command and exit code', () => {
+      const summary = getToolSummary(
+        'Bash',
+        JSON.stringify({ command: 'npm test' }),
+        'Tests passed\nexit code 0',
+      )
+      expect(summary).toContain('$')
+      expect(summary).toContain('npm test')
+    })
+
+    it('generates Read summary with path and line count', () => {
+      const content = makeLongContent(25)
+      const summary = getToolSummary(
+        'Read',
+        JSON.stringify({ file_path: '/src/index.ts' }),
+        content,
+      )
+      expect(summary).toContain('Read')
+      expect(summary).toContain('index.ts')
+      expect(summary).toContain('25 lines')
+    })
+
+    it('generates Edit summary with path and diff stats', () => {
+      const summary = getToolSummary(
+        'Edit',
+        JSON.stringify({ file_path: '/src/app.ts', old_string: 'foo\nbar', new_string: 'baz\nqux\nextra' }),
+        'Edited file',
+      )
+      expect(summary).toContain('Edited')
+      expect(summary).toContain('app.ts')
+    })
+
+    it('generates Search/Grep summary', () => {
+      const summary = getToolSummary(
+        'Grep',
+        JSON.stringify({ pattern: 'TODO' }),
+        'src/a.ts:10: TODO fix\nsrc/b.ts:20: TODO clean',
+      )
+      expect(summary).toContain('TODO')
+    })
+  })
+
+  describe('shouldAutoCollapse', () => {
+    it('returns false for content with 15 or fewer lines', () => {
+      expect(shouldAutoCollapse(makeLongContent(15))).toBe(false)
+    })
+
+    it('returns true for content with more than 15 lines', () => {
+      expect(shouldAutoCollapse(makeLongContent(16))).toBe(true)
+    })
+
+    it('returns false for empty content', () => {
+      expect(shouldAutoCollapse('')).toBe(false)
+    })
+  })
+
+  describe('getCollapsedPreviewLines', () => {
+    it('returns first 5 lines from content', () => {
+      const content = makeLongContent(20)
+      const preview = getCollapsedPreviewLines(content)
+      expect(preview.previewLines).toHaveLength(5)
+      expect(preview.previewLines[0]).toBe('line 1')
+      expect(preview.previewLines[4]).toBe('line 5')
+    })
+
+    it('returns correct remaining line count', () => {
+      const content = makeLongContent(20)
+      const preview = getCollapsedPreviewLines(content)
+      expect(preview.remainingCount).toBe(15)
+    })
+
+    it('returns all lines when content has 5 or fewer lines', () => {
+      const content = makeLongContent(3)
+      const preview = getCollapsedPreviewLines(content)
+      expect(preview.previewLines).toHaveLength(3)
+      expect(preview.remainingCount).toBe(0)
+    })
+  })
+})
+
+describe('CollapsibleToolOutput (rendered)', () => {
+  // Dynamically import after mocks
+  let CollapsibleToolOutput: React.ComponentType<any>
+
+  beforeEach(async () => {
+    const mod = await import('../ToolBlockSummary')
+    CollapsibleToolOutput = mod.CollapsibleToolOutput
+  })
+
+  it('auto-collapses output with >15 lines', () => {
+    const content = makeLongContent(20)
+    render(
+      <CollapsibleToolOutput
+        toolName="Bash"
+        toolInput={JSON.stringify({ command: 'ls -la' })}
+        content={content}
+        toolStatus="completed"
+      />,
+    )
+    // Should show "Show N more lines" button
+    expect(screen.getByTestId('show-more-btn')).toBeTruthy()
+    expect(screen.getByTestId('show-more-btn').textContent).toContain('15')
+  })
+
+  it('shows first 5 lines when collapsed', () => {
+    const content = makeLongContent(20)
+    render(
+      <CollapsibleToolOutput
+        toolName="Bash"
+        toolInput={JSON.stringify({ command: 'ls -la' })}
+        content={content}
+        toolStatus="completed"
+      />,
+    )
+    const preview = screen.getByTestId('tool-output-preview')
+    expect(preview.textContent).toContain('line 1')
+    expect(preview.textContent).toContain('line 5')
+    expect(preview.textContent).not.toContain('line 6')
+  })
+
+  it('does not auto-collapse output with <=15 lines', () => {
+    const content = makeLongContent(10)
+    render(
+      <CollapsibleToolOutput
+        toolName="Read"
+        toolInput={JSON.stringify({ file_path: '/foo.ts' })}
+        content={content}
+        toolStatus="completed"
+      />,
+    )
+    expect(screen.queryByTestId('show-more-btn')).toBeNull()
+  })
+
+  it('expands on click and shows all content', () => {
+    const content = makeLongContent(20)
+    render(
+      <CollapsibleToolOutput
+        toolName="Bash"
+        toolInput={JSON.stringify({ command: 'test' })}
+        content={content}
+        toolStatus="completed"
+      />,
+    )
+    const btn = screen.getByTestId('show-more-btn')
+    fireEvent.click(btn)
+    // After expand, the full content should be visible
+    const fullOutput = screen.getByTestId('tool-output-full')
+    expect(fullOutput.textContent).toContain('line 20')
+    // And a collapse button should appear
+    expect(screen.getByTestId('show-less-btn')).toBeTruthy()
+  })
+
+  it('each block has independent expand/collapse', () => {
+    const content1 = makeLongContent(20)
+    const content2 = makeLongContent(25)
+    const { container } = render(
+      <div>
+        <CollapsibleToolOutput
+          toolName="Bash"
+          toolInput={JSON.stringify({ command: 'cmd1' })}
+          content={content1}
+          toolStatus="completed"
+        />
+        <CollapsibleToolOutput
+          toolName="Read"
+          toolInput={JSON.stringify({ file_path: '/x.ts' })}
+          content={content2}
+          toolStatus="completed"
+        />
+      </div>,
+    )
+    const showMoreBtns = screen.getAllByTestId('show-more-btn')
+    expect(showMoreBtns).toHaveLength(2)
+
+    // Expand first, second should remain collapsed
+    fireEvent.click(showMoreBtns[0])
+    const fullOutputs = screen.getAllByTestId('tool-output-full')
+    expect(fullOutputs).toHaveLength(1)
+    // Second block still collapsed
+    expect(screen.getAllByTestId('show-more-btn')).toHaveLength(1)
+  })
+
+  it('shows correct icon name in summary header for Bash', () => {
+    const content = makeLongContent(20)
+    render(
+      <CollapsibleToolOutput
+        toolName="Bash"
+        toolInput={JSON.stringify({ command: 'npm run build' })}
+        content={content}
+        toolStatus="completed"
+      />,
+    )
+    const header = screen.getByTestId('tool-block-header')
+    expect(header.textContent).toContain('$')
+    expect(header.textContent).toContain('npm run build')
+  })
+
+  it('shows correct icon for Read tool', () => {
+    render(
+      <CollapsibleToolOutput
+        toolName="Read"
+        toolInput={JSON.stringify({ file_path: '/src/types.ts' })}
+        content={makeLongContent(20)}
+        toolStatus="completed"
+      />,
+    )
+    const header = screen.getByTestId('tool-block-header')
+    expect(header.textContent).toContain('Read')
+    expect(header.textContent).toContain('types.ts')
+  })
+})


### PR DESCRIPTION
## Summary
- Auto-collapse tool output >15 lines (shows first 5 + "Show N more")
- Per-tool-type icons: Terminal (bash), FileText (read), PencilSimple (edit), MagnifyingGlass (search)
- 1-line smart summaries per tool type
- Independent expand/collapse per block with Framer Motion

## Files
- `src/renderer/components/ToolBlockSummary.tsx` (NEW) — 26 tests
- `src/renderer/components/ToolTimeline.tsx` — integration

Closes #189