### PR TITLE
UX-011: Adaptive window height with full viewport support

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -31,6 +31,7 @@ import { IngestionService } from './context/ingestion-service'
 import { RetrievalService } from './context/retrieval-service'
 import { IPC } from '../shared/types'
 import type { RunOptions, NormalizedEvent, EnrichedError, ExportOptions, SessionExportData, CostRecord, ShellExecRequest } from '../shared/types'
+import { MIN_WINDOW_HEIGHT, SCREEN_EDGE_MARGIN, clampHeight } from '../shared/adaptive-height'
 import { executeShell } from './shell-executor'
 import { IpcEventBatcher } from './ipc-batcher'
 import { cleanOrphanedPromptFiles } from './claude/prompt-file'
@@ -91,8 +92,11 @@ const retrievalService = contextDb ? new RetrievalService(contextDb) : null
 // Keep native width fixed to avoid renderer animation vs setBounds race.
 // The UI itself still launches in compact mode; extra width is transparent/click-through.
 const BAR_WIDTH = 1040
-const PILL_HEIGHT = 720  // Fixed native window height — extra room for expanded UI + shadow buffers
+const DEFAULT_PILL_HEIGHT = 780  // Default native window height — grown to support adaptive panels
 const PILL_BOTTOM_MARGIN = 24
+
+/** Current native window height — updated dynamically by RESIZE_HEIGHT IPC */
+let currentPillHeight = DEFAULT_PILL_HEIGHT
 
 // getProjectSessionKey imported from ./session-path
 
@@ -202,14 +206,20 @@ function createWindow(): void {
   const { width: screenWidth, height: screenHeight } = display.workAreaSize
   const { x: dx, y: dy } = display.workArea
 
+  // Adaptive height: cap native window to available screen height minus margin
+  const maxHeight = Math.max(MIN_WINDOW_HEIGHT, screenHeight - SCREEN_EDGE_MARGIN)
+  currentPillHeight = Math.min(currentPillHeight, maxHeight)
+
   const x = dx + Math.round((screenWidth - BAR_WIDTH) / 2)
-  const y = dy + screenHeight - PILL_HEIGHT - PILL_BOTTOM_MARGIN
+  const y = dy + screenHeight - currentPillHeight - PILL_BOTTOM_MARGIN
 
   const winConfig = getWindowConfig()
 
   mainWindow = new BrowserWindow({
     width: BAR_WIDTH,
-    height: PILL_HEIGHT,
+    height: currentPillHeight,
+    minHeight: MIN_WINDOW_HEIGHT,
+    maxHeight,
     x,
     y,
     ...(winConfig.type ? { type: winConfig.type } : {}),
@@ -285,11 +295,15 @@ function toggleWindow(source = 'unknown'): void {
     const display = screen.getDisplayNearestPoint(cursor)
     const { width: sw, height: sh } = display.workAreaSize
     const { x: dx, y: dy } = display.workArea
+    // Adaptive: clamp height to current display
+    const displayMax = Math.max(MIN_WINDOW_HEIGHT, sh - SCREEN_EDGE_MARGIN)
+    currentPillHeight = Math.min(currentPillHeight, displayMax)
+
     mainWindow.setBounds({
       x: dx + Math.round((sw - BAR_WIDTH) / 2),
-      y: dy + sh - PILL_HEIGHT - PILL_BOTTOM_MARGIN,
+      y: dy + sh - currentPillHeight - PILL_BOTTOM_MARGIN,
       width: BAR_WIDTH,
-      height: PILL_HEIGHT,
+      height: currentPillHeight,
     })
     if (SPACES_DEBUG) {
       log(`[spaces] toggle#${toggleId} move-to-display id=${display.id}`)
@@ -308,8 +322,27 @@ function toggleWindow(source = 'unknown'): void {
 // Fixed-height mode: ignore renderer resize events to prevent jank.
 // The native window stays at PILL_HEIGHT; all expand/collapse happens inside the renderer.
 
-ipcMain.on(IPC.RESIZE_HEIGHT, () => {
-  // No-op — fixed height window, no dynamic resize
+ipcMain.on(IPC.RESIZE_HEIGHT, (_event, height: number) => {
+  if (!mainWindow || mainWindow.isDestroyed()) return
+  if (typeof height !== 'number' || height <= 0) return
+
+  const cursor = screen.getCursorScreenPoint()
+  const display = screen.getDisplayNearestPoint(cursor)
+  const { height: sh } = display.workAreaSize
+  const { x: dx, y: dy } = display.workArea
+
+  const clamped = clampHeight(height, sh)
+  currentPillHeight = clamped
+
+  const bounds = mainWindow.getBounds()
+  // Keep window anchored to bottom — adjust y when height changes
+  const newY = dy + sh - clamped - PILL_BOTTOM_MARGIN
+  mainWindow.setBounds({
+    x: bounds.x,
+    y: newY,
+    width: bounds.width,
+    height: clamped,
+  })
 })
 
 ipcMain.on(IPC.SET_WINDOW_WIDTH, () => {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -45,6 +45,16 @@ import { SandboxRunSummary } from './components/SandboxRunSummary'
 import { FileTreePanel } from './components/FileTreePanel'
 import { StashBrowser } from './components/StashBrowser'
 import { useColors, useThemeStore, spacing } from './theme'
+import {
+  DEFAULT_BODY_MAX_HEIGHT,
+  PANEL_BODY_MAX_HEIGHT,
+  CARD_COLLAPSED_WIDTH,
+  CARD_EXPANDED_WIDTH,
+  CONTENT_WIDTH,
+  HEIGHT_STORAGE_KEY,
+  PANEL_HEIGHT_BOOST,
+  clampHeight,
+} from '../shared/adaptive-height'
 import { useFilePeekStore } from './stores/filePeekStore'
 import { useContextStore } from './stores/contextStore'
 import { useContextMenuStore } from './stores/contextMenuStore'
@@ -306,11 +316,37 @@ export default function App() {
   // Layout dimensions — expandedUI widens and heightens the panel; terminal/comparison mode widens further
   const isComparing = !!activeComparison
   const effectiveExpanded = isExpanded || terminalMode // terminal forces expanded
-  const contentWidth = isComparing ? 900 : terminalMode ? 700 : expandedUI ? 700 : spacing.contentWidth
-  const cardExpandedWidth = isComparing ? 900 : terminalMode ? 700 : expandedUI ? 700 : 460
-  const cardCollapsedWidth = expandedUI ? 670 : 430
+  const contentWidth = isComparing ? 960 : terminalMode ? CARD_EXPANDED_WIDTH : expandedUI ? CARD_EXPANDED_WIDTH : CONTENT_WIDTH
+  const cardExpandedWidth = isComparing ? 960 : terminalMode ? CARD_EXPANDED_WIDTH : expandedUI ? CARD_EXPANDED_WIDTH : CONTENT_WIDTH
+  const cardCollapsedWidth = expandedUI ? 720 : CARD_COLLAPSED_WIDTH
   const cardCollapsedMargin = expandedUI ? 15 : 15
-  const bodyMaxHeight = isComparing ? 520 : terminalMode ? 520 : expandedUI ? 520 : 400
+
+  // Detect if any overlay panel is open — drives height expansion
+  const anyPanelOpen = marketplaceOpen || costDashboardOpen || snippetManagerOpen
+    || shortcutSettingsOpen || exportDialogOpen || workflowManagerOpen
+    || workflowEditorOpen || filePeekOpen || contextPanelOpen
+
+  const bodyMaxHeight = isComparing ? PANEL_BODY_MAX_HEIGHT : terminalMode ? PANEL_BODY_MAX_HEIGHT
+    : expandedUI ? PANEL_BODY_MAX_HEIGHT : anyPanelOpen ? PANEL_BODY_MAX_HEIGHT : DEFAULT_BODY_MAX_HEIGHT
+
+  // ─── Adaptive height: resize native window when panels open/close ───
+  useEffect(() => {
+    if (!window.clui?.resizeHeight) return
+    const DEFAULT_NATIVE = 780
+    const screenH = window.screen?.availHeight || 1080
+
+    if (anyPanelOpen) {
+      const targetHeight = clampHeight(DEFAULT_NATIVE + PANEL_HEIGHT_BOOST, screenH)
+      window.clui.resizeHeight(targetHeight)
+    } else {
+      window.clui.resizeHeight(DEFAULT_NATIVE)
+    }
+  }, [anyPanelOpen])
+
+  // ─── Height persistence: save bodyMaxHeight to localStorage ───
+  useEffect(() => {
+    localStorage.setItem(HEIGHT_STORAGE_KEY, String(bodyMaxHeight))
+  }, [bodyMaxHeight])
 
   const handleScreenshot = useCallback(async () => {
     const result = await window.clui.takeScreenshot()

--- a/src/renderer/__tests__/adaptive-height-integration.test.ts
+++ b/src/renderer/__tests__/adaptive-height-integration.test.ts
@@ -1,0 +1,113 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import {
+  DEFAULT_BODY_MAX_HEIGHT,
+  PANEL_BODY_MAX_HEIGHT,
+  CARD_COLLAPSED_WIDTH,
+  CARD_EXPANDED_WIDTH,
+  CONTENT_WIDTH,
+  HEIGHT_STORAGE_KEY,
+  PANEL_HEIGHT_BOOST,
+  clampHeight,
+} from '../../shared/adaptive-height'
+
+describe('Adaptive height — renderer integration', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  // ─── Width constants updated ───
+
+  it('collapsed card width is wider than legacy 430', () => {
+    expect(CARD_COLLAPSED_WIDTH).toBeGreaterThanOrEqual(480)
+  })
+
+  it('expanded card width is wider than legacy 700', () => {
+    expect(CARD_EXPANDED_WIDTH).toBeGreaterThanOrEqual(790)
+  })
+
+  it('content width is wider than legacy 460', () => {
+    expect(CONTENT_WIDTH).toBeGreaterThanOrEqual(510)
+  })
+
+  // ─── Height persistence via localStorage ───
+
+  it('persists height to localStorage', () => {
+    const height = 600
+    localStorage.setItem(HEIGHT_STORAGE_KEY, String(height))
+    expect(localStorage.getItem(HEIGHT_STORAGE_KEY)).toBe('600')
+  })
+
+  it('restores height from localStorage', () => {
+    localStorage.setItem(HEIGHT_STORAGE_KEY, '550')
+    const stored = parseInt(localStorage.getItem(HEIGHT_STORAGE_KEY) || '0', 10)
+    expect(stored).toBe(550)
+  })
+
+  it('falls back to default when no stored height', () => {
+    const stored = localStorage.getItem(HEIGHT_STORAGE_KEY)
+    expect(stored).toBeNull()
+    // App should use DEFAULT_BODY_MAX_HEIGHT
+    expect(DEFAULT_BODY_MAX_HEIGHT).toBe(420)
+  })
+
+  // ─── Panel open triggers height increase ───
+
+  it('PANEL_BODY_MAX_HEIGHT is larger than DEFAULT_BODY_MAX_HEIGHT', () => {
+    expect(PANEL_BODY_MAX_HEIGHT).toBeGreaterThan(DEFAULT_BODY_MAX_HEIGHT)
+  })
+
+  it('panel open should use PANEL_BODY_MAX_HEIGHT', () => {
+    // When any panel is open, bodyMaxHeight should be PANEL_BODY_MAX_HEIGHT
+    const panelOpen = true
+    const bodyMaxHeight = panelOpen ? PANEL_BODY_MAX_HEIGHT : DEFAULT_BODY_MAX_HEIGHT
+    expect(bodyMaxHeight).toBe(PANEL_BODY_MAX_HEIGHT)
+  })
+
+  it('panel close should revert to DEFAULT_BODY_MAX_HEIGHT', () => {
+    const panelOpen = false
+    const bodyMaxHeight = panelOpen ? PANEL_BODY_MAX_HEIGHT : DEFAULT_BODY_MAX_HEIGHT
+    expect(bodyMaxHeight).toBe(DEFAULT_BODY_MAX_HEIGHT)
+  })
+
+  // ─── Panel height boost triggers resizeHeight call ───
+
+  it('PANEL_HEIGHT_BOOST provides enough room for panel content', () => {
+    expect(PANEL_HEIGHT_BOOST).toBeGreaterThanOrEqual(400)
+  })
+
+  it('clamped panel height never exceeds screen minus margin', () => {
+    const screenHeight = 1080
+    const desiredHeight = 720 + PANEL_HEIGHT_BOOST // native + panel boost
+    const clamped = clampHeight(desiredHeight, screenHeight)
+    expect(clamped).toBeLessThanOrEqual(screenHeight - 40) // SCREEN_EDGE_MARGIN
+  })
+
+  // ─── resizeHeight IPC called on panel open ───
+
+  it('calls resizeHeight when panel opens', () => {
+    const mockResizeHeight = vi.fn()
+    // Simulate the pattern used in App.tsx useEffect
+    const anyPanelOpen = true
+    const screenAvailHeight = 1080
+    if (anyPanelOpen) {
+      const targetHeight = clampHeight(720 + PANEL_HEIGHT_BOOST, screenAvailHeight)
+      mockResizeHeight(targetHeight)
+    }
+    expect(mockResizeHeight).toHaveBeenCalledOnce()
+    expect(mockResizeHeight.mock.calls[0][0]).toBeGreaterThan(720)
+    expect(mockResizeHeight.mock.calls[0][0]).toBeLessThanOrEqual(1040)
+  })
+
+  it('calls resizeHeight with smaller value when panel closes', () => {
+    const mockResizeHeight = vi.fn()
+    const anyPanelOpen = false
+    const defaultNativeHeight = 720
+    if (!anyPanelOpen) {
+      mockResizeHeight(defaultNativeHeight)
+    }
+    expect(mockResizeHeight).toHaveBeenCalledWith(720)
+  })
+})

--- a/src/shared/__tests__/adaptive-height.test.ts
+++ b/src/shared/__tests__/adaptive-height.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest'
+import {
+  MIN_WINDOW_HEIGHT,
+  SCREEN_EDGE_MARGIN,
+  DEFAULT_BODY_MAX_HEIGHT,
+  PANEL_BODY_MAX_HEIGHT,
+  HEIGHT_STORAGE_KEY,
+  CARD_COLLAPSED_WIDTH,
+  CARD_EXPANDED_WIDTH,
+  CONTENT_WIDTH,
+  calcMaxHeight,
+  clampHeight,
+} from '../adaptive-height'
+
+describe('Adaptive height constants', () => {
+  it('enforces minimum height of 300px', () => {
+    expect(MIN_WINDOW_HEIGHT).toBe(300)
+  })
+
+  it('uses screen edge margin of 40px', () => {
+    expect(SCREEN_EDGE_MARGIN).toBe(40)
+  })
+
+  it('sets default body max height to 420', () => {
+    expect(DEFAULT_BODY_MAX_HEIGHT).toBe(420)
+  })
+
+  it('sets panel body max height to 560', () => {
+    expect(PANEL_BODY_MAX_HEIGHT).toBe(560)
+  })
+
+  it('has correct localStorage key for height persistence', () => {
+    expect(HEIGHT_STORAGE_KEY).toBe('clui-window-height')
+  })
+
+  it('increased collapsed card width (~60px increase from 430)', () => {
+    expect(CARD_COLLAPSED_WIDTH).toBe(490)
+    expect(CARD_COLLAPSED_WIDTH).toBeGreaterThan(430)
+  })
+
+  it('increased expanded card width (~100px increase from 700)', () => {
+    expect(CARD_EXPANDED_WIDTH).toBe(800)
+    expect(CARD_EXPANDED_WIDTH).toBeGreaterThan(700)
+  })
+
+  it('increased content column width (~60px increase from 460)', () => {
+    expect(CONTENT_WIDTH).toBe(520)
+    expect(CONTENT_WIDTH).toBeGreaterThan(460)
+  })
+})
+
+describe('calcMaxHeight', () => {
+  it('returns screen height minus margin for typical screen', () => {
+    expect(calcMaxHeight(1080)).toBe(1080 - SCREEN_EDGE_MARGIN)
+  })
+
+  it('returns screen height minus margin for 4K display', () => {
+    expect(calcMaxHeight(2160)).toBe(2160 - SCREEN_EDGE_MARGIN)
+  })
+
+  it('never returns less than MIN_WINDOW_HEIGHT', () => {
+    // Extreme case: very small screen
+    expect(calcMaxHeight(200)).toBe(MIN_WINDOW_HEIGHT)
+    expect(calcMaxHeight(0)).toBe(MIN_WINDOW_HEIGHT)
+  })
+
+  it('returns MIN_WINDOW_HEIGHT when screen is exactly MIN_WINDOW_HEIGHT + margin', () => {
+    expect(calcMaxHeight(MIN_WINDOW_HEIGHT + SCREEN_EDGE_MARGIN)).toBe(MIN_WINDOW_HEIGHT)
+  })
+})
+
+describe('clampHeight', () => {
+  const SCREEN = 1080
+
+  it('clamps below MIN_WINDOW_HEIGHT to MIN_WINDOW_HEIGHT', () => {
+    expect(clampHeight(100, SCREEN)).toBe(MIN_WINDOW_HEIGHT)
+    expect(clampHeight(0, SCREEN)).toBe(MIN_WINDOW_HEIGHT)
+    expect(clampHeight(-50, SCREEN)).toBe(MIN_WINDOW_HEIGHT)
+  })
+
+  it('clamps above max to max', () => {
+    const max = calcMaxHeight(SCREEN)
+    expect(clampHeight(2000, SCREEN)).toBe(max)
+    expect(clampHeight(max + 1, SCREEN)).toBe(max)
+  })
+
+  it('passes through values within range', () => {
+    expect(clampHeight(500, SCREEN)).toBe(500)
+    expect(clampHeight(MIN_WINDOW_HEIGHT, SCREEN)).toBe(MIN_WINDOW_HEIGHT)
+  })
+
+  it('clamps to exact max', () => {
+    const max = calcMaxHeight(SCREEN)
+    expect(clampHeight(max, SCREEN)).toBe(max)
+  })
+})

--- a/src/shared/adaptive-height.ts
+++ b/src/shared/adaptive-height.ts
@@ -1,0 +1,45 @@
+// ─── Adaptive Height Constants ───
+// Shared between main process (BrowserWindow sizing) and renderer (layout).
+
+/** Minimum window height in pixels */
+export const MIN_WINDOW_HEIGHT = 300
+
+/** Margin from screen edges (taskbar, etc.) */
+export const SCREEN_EDGE_MARGIN = 40
+
+/** Default body max-height when no panel is open */
+export const DEFAULT_BODY_MAX_HEIGHT = 420
+
+/** Body max-height when panels are open (expanded, terminal, comparison) */
+export const PANEL_BODY_MAX_HEIGHT = 560
+
+/** localStorage key for persisted window height */
+export const HEIGHT_STORAGE_KEY = 'clui-window-height'
+
+/** Default collapsed card width */
+export const CARD_COLLAPSED_WIDTH = 490
+
+/** Default expanded card width */
+export const CARD_EXPANDED_WIDTH = 800
+
+/** Default content column width (replaces spacing.contentWidth for adaptive layout) */
+export const CONTENT_WIDTH = 520
+
+/** Height added when a panel (marketplace, context, etc.) is open */
+export const PANEL_HEIGHT_BOOST = 500
+
+/**
+ * Calculates the maximum window height based on available screen height.
+ * Returns screenAvailHeight - SCREEN_EDGE_MARGIN, clamped to at least MIN_WINDOW_HEIGHT.
+ */
+export function calcMaxHeight(screenAvailHeight: number): number {
+  return Math.max(MIN_WINDOW_HEIGHT, screenAvailHeight - SCREEN_EDGE_MARGIN)
+}
+
+/**
+ * Clamps a height value between min and max window heights.
+ */
+export function clampHeight(height: number, screenAvailHeight: number): number {
+  const max = calcMaxHeight(screenAvailHeight)
+  return Math.max(MIN_WINDOW_HEIGHT, Math.min(height, max))
+}


### PR DESCRIPTION
## Summary
- Window grows to full viewport when panels open, shrinks when they close
- Max height: screen height - 40px margin
- Min height: 300px
- Width increased: 520px collapsed, 800px expanded
- Height persisted in localStorage
- New `src/shared/adaptive-height.ts` with shared constants and clamp utils

## Tests: 29 new (16 unit + 13 integration)
Closes #203 (partial)