### PR TITLE
UX-011: InputBar, StatusBar upgrade and microinteractions

### DIFF
--- a/src/renderer/components/InputBar.tsx
+++ b/src/renderer/components/InputBar.tsx
@@ -18,7 +18,7 @@ import { parseTemplate, findNextSlot, findPreviousSlot, resolveVariables, hasSlo
 import type { AgentAssignment, AgentMemorySnapshot, SessionExportData } from '../../shared/types'
 
 const INPUT_MIN_HEIGHT = 20
-const INPUT_MAX_HEIGHT = 140
+export const INPUT_MAX_HEIGHT = 220
 const MULTILINE_ENTER_HEIGHT = 52
 const MULTILINE_EXIT_HEIGHT = 50
 const INLINE_CONTROLS_RESERVED_WIDTH = 104
@@ -81,6 +81,7 @@ export function InputBar() {
   const [lintWarnings, setLintWarnings] = useState<PromptLintWarning[]>([])
   const lintTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const [slotMode, setSlotMode] = useState(false)
+  const [isFocused, setIsFocused] = useState(false)
 
   const sendMessage = useSessionStore((s) => s.sendMessage)
   const clearTab = useSessionStore((s) => s.clearTab)
@@ -908,8 +909,26 @@ export function InputBar() {
         )}
       </AnimatePresence>
 
+      {/* Hint text — visible when textarea empty and idle */}
+      {!input && !isBusy && !isConnecting && voiceState === 'idle' && (
+        <div
+          data-testid="newline-hint"
+          className="text-[10px] px-1"
+          style={{ color: colors.textMuted, marginBottom: 2 }}
+        >
+          Shift+Enter for newline
+        </div>
+      )}
+
       {/* Single-line: inline controls. Multi-line: controls in bottom row */}
-      <div className="w-full" style={{ minHeight: 50 }}>
+      <div
+        className="w-full rounded-xl transition-shadow"
+        style={{
+          minHeight: 50,
+          boxShadow: isFocused ? `0 0 0 2px rgba(217,119,87,0.2)` : 'none',
+          transition: 'box-shadow 0.15s ease',
+        }}
+      >
         {isMultiLine ? (
           <div className="w-full">
             <textarea
@@ -921,6 +940,8 @@ export function InputBar() {
               onChange={handleInputChange}
               onKeyDown={handleKeyDown}
               onPaste={handlePaste}
+              onFocus={() => setIsFocused(true)}
+              onBlur={() => setIsFocused(false)}
               placeholder={
                 isConnecting
                   ? 'Initializing...'
@@ -961,11 +982,15 @@ export function InputBar() {
                       data-testid="composer-send"
                       onMouseDown={(e) => e.preventDefault()}
                       onClick={handleSend}
-                      className="w-9 h-9 rounded-full flex items-center justify-center transition-colors"
-                      style={{ background: colors.sendBg, color: colors.textOnAccent }}
+                      className="w-10 h-10 rounded-full flex items-center justify-center transition-all clui-pressable"
+                      style={{
+                        background: colors.sendBg,
+                        color: colors.textOnAccent,
+                        boxShadow: '0 1px 4px rgba(0,0,0,0.15)',
+                      }}
                       title={isBusy ? 'Queue message' : 'Send (Enter)'}
                     >
-                      <ArrowUp size={16} weight="bold" />
+                      <ArrowUp size={17} weight="bold" />
                     </button>
                   </motion.div>
                 )}
@@ -983,6 +1008,8 @@ export function InputBar() {
               onChange={handleInputChange}
               onKeyDown={handleKeyDown}
               onPaste={handlePaste}
+              onFocus={() => setIsFocused(true)}
+              onBlur={() => setIsFocused(false)}
               placeholder={
                 isConnecting
                   ? 'Initializing...'
@@ -1023,11 +1050,15 @@ export function InputBar() {
                       data-testid="composer-send"
                       onMouseDown={(e) => e.preventDefault()}
                       onClick={handleSend}
-                      className="w-9 h-9 rounded-full flex items-center justify-center transition-colors"
-                      style={{ background: colors.sendBg, color: colors.textOnAccent }}
+                      className="w-10 h-10 rounded-full flex items-center justify-center transition-all clui-pressable"
+                      style={{
+                        background: colors.sendBg,
+                        color: colors.textOnAccent,
+                        boxShadow: '0 1px 4px rgba(0,0,0,0.15)',
+                      }}
                       title={isBusy ? 'Queue message' : 'Send (Enter)'}
                     >
-                      <ArrowUp size={16} weight="bold" />
+                      <ArrowUp size={17} weight="bold" />
                     </button>
                   </motion.div>
                 )}

--- a/src/renderer/components/StatusBar.tsx
+++ b/src/renderer/components/StatusBar.tsx
@@ -71,7 +71,7 @@ function ModelPicker() {
       <button
         ref={triggerRef}
         onClick={handleToggle}
-        className="flex items-center gap-0.5 text-[10px] rounded-full px-1.5 py-0.5 transition-colors"
+        className="flex items-center gap-0.5 text-[11px] font-medium rounded-full px-1.5 py-0.5 transition-colors clui-interactive"
         style={{
           color: colors.textTertiary,
           cursor: isBusy ? 'not-allowed' : 'pointer',
@@ -79,7 +79,7 @@ function ModelPicker() {
         title={isBusy ? 'Stop the task to change model' : 'Switch model'}
       >
         {activeLabel}
-        <CaretDown size={10} style={{ opacity: 0.6 }} />
+        <CaretDown size={14} style={{ opacity: 0.6 }} />
       </button>
 
       {popoverLayer && open && createPortal(
@@ -176,16 +176,16 @@ function PermissionModePicker() {
       <button
         ref={triggerRef}
         onClick={handleToggle}
-        className="flex items-center gap-0.5 text-[10px] rounded-full px-1.5 py-0.5 transition-colors"
+        className="flex items-center gap-0.5 text-[11px] rounded-full px-1.5 py-0.5 transition-colors clui-interactive"
         style={{
           color: colors.textTertiary,
           cursor: 'pointer',
         }}
         title="Permission mode (global)"
       >
-        <ShieldCheck size={11} weight={isAuto ? 'fill' : 'regular'} />
+        <ShieldCheck size={14} weight={isAuto ? 'fill' : 'regular'} />
         {isAuto ? 'Auto' : 'Ask'}
-        <CaretDown size={10} style={{ opacity: 0.6 }} />
+        <CaretDown size={14} style={{ opacity: 0.6 }} />
       </button>
 
       {popoverLayer && open && createPortal(
@@ -281,7 +281,7 @@ function TokenIndicator() {
       }}
       title={`Input: ${formatTokenCount(tokenUsage.inputTokens)} | Output: ${formatTokenCount(tokenUsage.outputTokens)} | Cache read: ${formatTokenCount(tokenUsage.cacheReadTokens)} | Cache write: ${formatTokenCount(tokenUsage.cacheWriteTokens)}`}
     >
-      <Lightning size={10} weight={isLarge ? 'fill' : 'regular'} />
+      <Lightning size={14} weight={isLarge ? 'fill' : 'regular'} />
       {formatTokenCount(tokenUsage.totalTokens)}
     </span>
   )
@@ -452,11 +452,12 @@ export function StatusBar() {
 
   return (
     <div
+      data-testid="status-bar"
       className="flex items-center justify-between px-4 py-1.5"
       style={{ minHeight: 28 }}
     >
       {/* Left — directory + model picker */}
-      <div className="flex items-center gap-2 text-[11px] min-w-0" style={{ color: colors.textTertiary }}>
+      <div className="flex items-center gap-3 text-[11px] min-w-0" style={{ color: colors.textTertiary }}>
         {/* Directory button */}
         <button
           ref={dirRef}
@@ -470,7 +471,7 @@ export function StatusBar() {
           title={dirTooltip}
           disabled={isRunning}
         >
-          <FolderOpen size={11} className="flex-shrink-0" />
+          <FolderOpen size={14} className="flex-shrink-0" />
           <span className="truncate">{tab.hasChosenDirectory ? compactPath(tab.workingDirectory) : '—'}</span>
           {hasExtraDirs && (
             <span style={{ color: colors.textTertiary, fontWeight: 600 }}>+{tab.additionalDirs.length}</span>
@@ -615,11 +616,7 @@ export function StatusBar() {
           popoverLayer,
         )}
 
-        <span style={{ color: colors.textMuted, fontSize: 10 }}>|</span>
-
         <ModelPicker />
-
-        <span style={{ color: colors.textMuted, fontSize: 10 }}>|</span>
 
         <PermissionModePicker />
 
@@ -627,7 +624,6 @@ export function StatusBar() {
 
         {tab.agentAssignment && (
           <>
-            <span style={{ color: colors.textMuted, fontSize: 10 }}>|</span>
             <span
               className="max-w-[220px] truncate rounded-full px-1.5 py-0.5 text-[10px]"
               style={{
@@ -654,7 +650,7 @@ export function StatusBar() {
           title="Open this session in Terminal"
         >
           Open in CLI
-          <Terminal size={11} />
+          <Terminal size={14} />
         </button>
       </div>
     </div>

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -210,3 +210,23 @@ input::placeholder {
 .no-drag {
   -webkit-app-region: no-drag;
 }
+
+/* ─── Global microinteractions ─── */
+.clui-pressable {
+  transition: transform 0.1s ease;
+}
+.clui-pressable:active {
+  transform: scale(0.96);
+}
+
+.clui-interactive {
+  transition: background-color 0.15s ease;
+}
+.clui-interactive:hover {
+  background-color: var(--clui-surface-hover);
+}
+
+.clui-focus-ring:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--clui-accent-glow, rgba(217,119,87,0.25));
+}

--- a/tests/renderer/components/InputBarControls.test.tsx
+++ b/tests/renderer/components/InputBarControls.test.tsx
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+
+import React from 'react'
+import { screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { InputBar } from '../../../src/renderer/components/InputBar'
+import { StatusBar } from '../../../src/renderer/components/StatusBar'
+import { useSessionStore } from '../../../src/renderer/stores/sessionStore'
+import { renderWithProviders, resetTestState, makeTab } from '../testUtils'
+
+describe('InputBar Controls Upgrade', () => {
+  beforeEach(() => {
+    resetTestState()
+    useSessionStore.setState({
+      tabs: [makeTab({ id: 'tab-1', title: 'Chat' })],
+      activeTabId: 'tab-1',
+      staticInfo: {
+        version: '1.0.0',
+        email: 'user@example.com',
+        subscriptionType: 'pro',
+        projectPath: 'C:/repo',
+        homePath: 'C:/Users/test',
+      },
+    })
+  })
+
+  it('INPUT_MAX_HEIGHT is at least 200', async () => {
+    // Import the constant directly — it's module-scoped
+    const mod = await import('../../../src/renderer/components/InputBar')
+    // We export INPUT_MAX_HEIGHT for testability
+    expect((mod as Record<string, unknown>).INPUT_MAX_HEIGHT).toBeGreaterThanOrEqual(200)
+  })
+
+  it('send button has accent background color and minimum 36px size', () => {
+    useSessionStore.setState({
+      tabs: [makeTab({ id: 'tab-1', title: 'Chat' })],
+      activeTabId: 'tab-1',
+      staticInfo: {
+        version: '1.0.0',
+        email: 'user@example.com',
+        subscriptionType: 'pro',
+        projectPath: 'C:/repo',
+        homePath: 'C:/Users/test',
+      },
+    })
+    renderWithProviders(<InputBar />)
+
+    // Type something so the send button appears
+    const input = screen.getByTestId('composer-input')
+    input.focus()
+    const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+      window.HTMLTextAreaElement.prototype,
+      'value',
+    )!.set!
+    nativeInputValueSetter.call(input, 'Hello')
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+    input.dispatchEvent(new Event('change', { bubbles: true }))
+
+    // The send button should now be visible
+    const sendBtn = screen.getByTestId('composer-send')
+    expect(sendBtn).toBeInTheDocument()
+
+    // Check accent background via inline style
+    const style = sendBtn.style
+    expect(style.background || style.backgroundColor).toBeTruthy()
+
+    // Check minimum size: the button should have w-[38px] h-[38px] or larger via class or style
+    // We check the className for size classes >= 36px
+    const classes = sendBtn.className
+    // Should have explicit width/height classes of at least 36px (w-9 = 36px, w-10 = 40px)
+    const hasMinSize = classes.includes('w-9') || classes.includes('w-10') ||
+      classes.includes('w-[36px]') || classes.includes('w-[38px]') || classes.includes('w-[40px]')
+    expect(hasMinSize).toBe(true)
+  })
+
+  it('textarea shows hint text when empty', () => {
+    renderWithProviders(<InputBar />)
+
+    // Look for the hint text element
+    const hint = screen.getByTestId('newline-hint')
+    expect(hint).toBeInTheDocument()
+    expect(hint.textContent).toContain('Shift+Enter')
+  })
+
+  it('send button is disabled with opacity when canSend is false', () => {
+    renderWithProviders(<InputBar />)
+
+    // With empty input, the send button should not be rendered (it uses AnimatePresence)
+    const sendBtn = screen.queryByTestId('composer-send')
+    expect(sendBtn).not.toBeInTheDocument()
+  })
+})
+
+describe('StatusBar Controls Upgrade', () => {
+  beforeEach(() => {
+    resetTestState()
+    useSessionStore.setState({
+      tabs: [makeTab({ id: 'tab-1', title: 'Chat' })],
+      activeTabId: 'tab-1',
+    })
+  })
+
+  it('has no pipe separator characters', () => {
+    renderWithProviders(<StatusBar />)
+
+    // The StatusBar should not contain literal pipe text nodes
+    const statusBar = screen.getByTestId('status-bar')
+    const textContent = statusBar.textContent || ''
+    // Pipe character should not appear as a separator
+    expect(textContent).not.toContain('|')
+  })
+
+  it('icons are at least 14px', () => {
+    renderWithProviders(<StatusBar />)
+
+    // Check that FolderOpen and Terminal icons use size >= 14
+    const statusBar = screen.getByTestId('status-bar')
+    const svgs = statusBar.querySelectorAll('svg')
+    for (const svg of Array.from(svgs)) {
+      const width = svg.getAttribute('width')
+      const height = svg.getAttribute('height')
+      if (width) {
+        expect(Number(width)).toBeGreaterThanOrEqual(14)
+      }
+      if (height) {
+        expect(Number(height)).toBeGreaterThanOrEqual(14)
+      }
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- Send button: 40px, accent bg, press scale
- Textarea: focus glow ring, max height 220px
- "Shift+Enter for newline" hint
- StatusBar: no pipe separators, 14px icons, bolder model name
- Global CSS: .clui-pressable, .clui-interactive, .clui-focus-ring

## Tests: 6 new
Closes #203 (partial)