### PR TITLE
Fix terminal unresponsive: lightbox hijacking xterm WebGL canvas clicks

### DIFF
--- a/src/renderer/components/TerminalView.tsx
+++ b/src/renderer/components/TerminalView.tsx
@@ -524,7 +524,9 @@ export function TerminalView({ termTabId, isActive }: TerminalViewProps) {
       setLightboxSrc(target.src)
       return
     }
-    if (target instanceof HTMLCanvasElement) {
+    // Only open lightbox for image-protocol canvases, NOT xterm's own render canvas.
+    // xterm.js places its WebGL/canvas renderer inside .xterm-screen — skip those.
+    if (target instanceof HTMLCanvasElement && !target.closest('.xterm-screen')) {
       try {
         const dataUrl = target.toDataURL('image/png')
         if (dataUrl && dataUrl !== 'data:,') {


### PR DESCRIPTION
The TERM-005 image lightbox feature in handleTerminalClick was treating
xterm.js's own WebGL render canvas as a clickable image. Since the entire
terminal is rendered on a canvas element inside .xterm-screen, every click
opened a black lightbox overlay — blocking all keyboard and mouse input.

Fix: skip canvas elements inside .xterm-screen (xterm's render surface)
so only actual image-protocol canvases trigger the lightbox.

https://claude.ai/code/session_01Wt3JQkkkX9YQT5xugLYMo3